### PR TITLE
Add support to perform abilities while stunned

### DIFF
--- a/Game/Scripts/Models/Abilities/Ability.cs
+++ b/Game/Scripts/Models/Abilities/Ability.cs
@@ -15,6 +15,8 @@ public abstract class Ability<T> : Ability
 	private readonly Func<T, GDTask> _onAbilityEndedPerformed;
 
 	private readonly ConditionalAbilityCheckDelegate _conditionalAbilityCheck;
+	
+	public bool PerformWhileStunned { get; set; } = false;
 
 	public List<ScenarioEvent<ScenarioEvents.AbilityStarted.Parameters>.Subscription> AbilityStartedSubscriptions { get; }
 	public List<ScenarioEvent<ScenarioEvents.AbilityEnded.Parameters>.Subscription> AbilityEndedSubscriptions { get; }
@@ -41,6 +43,7 @@ public abstract class Ability<T> : Ability
 	{
 		T abilityState = new T()
 		{
+			PerformWhileStunned = PerformWhileStunned,
 			ActionState = actionState
 		};
 

--- a/Game/Scripts/Models/Abilities/AbilityState.cs
+++ b/Game/Scripts/Models/Abilities/AbilityState.cs
@@ -18,6 +18,7 @@ public abstract class AbilityState
 	public Figure Performer => ActionState.Performer;
 	public Figure Authority => ActionState.Authority;
 
+	public bool PerformWhileStunned { get; set; } = false;
 	public bool Blocked => _blocked || Performer.IsDead;
 
 	public void SetPerformed()

--- a/Game/Scripts/Models/Abilities/HealAbility.cs
+++ b/Game/Scripts/Models/Abilities/HealAbility.cs
@@ -42,7 +42,7 @@ public class HealAbility : TargetedAbility<HealAbility.State, HealAbility.HealAb
 
 	public HealAbility(DynamicInt<State> value, int targets = 1, int? range = null, RangeType? rangeType = null,
 		Target target = Target.SelfOrAllies,
-		bool requiresLineOfSight = true, bool mandatory = false,
+		bool requiresLineOfSight = true, bool mandatory = false, bool performWhileStunned = false,
 		Hex targetHex = null,
 		AOEPattern aoePattern = null, int push = 0, int pull = 0, ConditionModel[] conditions = null,
 		Action<State, List<Figure>> customGetTargets = null,
@@ -64,6 +64,7 @@ public class HealAbility : TargetedAbility<HealAbility.State, HealAbility.HealAb
 		DuringHealSubscriptions = duringHealSubscriptions;
 		AfterTargetConfirmedSubscriptions = afterTargetConfirmedSubscriptions;
 		AfterHealPerformedSubscriptions = afterHealPerformedSubscriptions;
+		PerformWhileStunned = performWhileStunned;
 	}
 
 	protected override void InitializeState(State abilityState)

--- a/Game/Scripts/Models/Conditions/Stun.cs
+++ b/Game/Scripts/Models/Conditions/Stun.cs
@@ -11,7 +11,7 @@ public class Stun : ConditionModel
 		await base.Add(target, node);
 
 		ScenarioEvents.AbilityStartedEvent.Subscribe(this,
-			parameters => parameters.Performer == Owner,
+			parameters => parameters.Performer == Owner && !parameters.AbilityState.PerformWhileStunned,
 			parameters =>
 			{
 				Node.Flash();

--- a/Game/Scripts/Scenario/HexObjects/Character.cs
+++ b/Game/Scripts/Scenario/HexObjects/Character.cs
@@ -363,7 +363,8 @@ public partial class Character : Figure
 			}
 		}
 
-		ActionState actionState = new ActionState(this, [new HealAbility(2, target: Target.Self)]);
+		HealAbility healAbility = new HealAbility(2, target: Target.Self, performWhileStunned: true);
+		ActionState actionState = new ActionState(this, [healAbility]);
 		await actionState.Perform();
 	}
 


### PR DESCRIPTION
Tested by adjusting an ability card such that a character could stun themselves, and verified that the long rest heal will trigger.