### PR TITLE
Mark damage prevented when final damage 0

### DIFF
--- a/Game/Content/Classes/Hierophant/Cards/Prayers/02_Grace.cs
+++ b/Game/Content/Classes/Hierophant/Cards/Prayers/02_Grace.cs
@@ -15,7 +15,10 @@ public class Grace : HierophantPrayerCardModel<Grace.CardTop, Grace.CardBottom>
 				async state =>
 				{
 					ScenarioEvents.AfterSufferDamageEvent.Subscribe(state, this,
-						canApplyParameters => canApplyParameters.SufferDamageParameters.Figure == state.Performer && !state.Performer.IsDead,
+						canApplyParameters =>
+							canApplyParameters.SufferDamageParameters.Figure == state.Performer
+							&& !state.Performer.IsDead
+							&& !canApplyParameters.SufferDamageParameters.DamagePrevented,
 						async applyParameters =>
 						{
 							ActionState actionState = new ActionState(state.Performer, [new HealAbility(3, target: Target.Self)]);

--- a/Game/Scripts/Scenario/ScenarioEvents/ScenarioEvents.cs
+++ b/Game/Scripts/Scenario/ScenarioEvents/ScenarioEvents.cs
@@ -332,6 +332,10 @@ public class ScenarioEvents
 				}
 
 				CalculatedCurrentDamage = finalDamage;
+				if (CalculatedCurrentDamage == 0)
+				{
+					DamagePrevented = true;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
- Update Grace to check if damage was prevented prior to applying.

Verified that prompts for damage mitigation are still displayed and work properly.
Once damage is mitigated to 0, no new prompts appear.