### PR TITLE
Fix Penitence; should not trigger on null or crit

### DIFF
--- a/Game/Content/Classes/Hierophant/Cards/Prayers/06_Penitence.cs
+++ b/Game/Content/Classes/Hierophant/Cards/Prayers/06_Penitence.cs
@@ -50,9 +50,9 @@ public class Penitence : HierophantPrayerCardModel<Penitence.CardTop, Penitence.
 				{
 					ScenarioEvents.AMDCardDrawnEvent.Subscribe(state, this,
 						canApplyParameters =>
-							state.Performer.EnemiesWith(canApplyParameters.AbilityState.Performer)
-							&& canApplyParameters.Value > 0
-							&& !canApplyParameters.AMDCard.IsCrit,
+							state.Performer.EnemiesWith(canApplyParameters.AbilityState.Performer) &&
+							canApplyParameters.Value > 0 &&
+							!canApplyParameters.AMDCard.IsCrit,
 						async applyParameters =>
 						{
 							applyParameters.SetValue(0);

--- a/Game/Content/Classes/Hierophant/Cards/Prayers/06_Penitence.cs
+++ b/Game/Content/Classes/Hierophant/Cards/Prayers/06_Penitence.cs
@@ -16,9 +16,9 @@ public class Penitence : HierophantPrayerCardModel<Penitence.CardTop, Penitence.
 				{
 					ScenarioEvents.AMDCardDrawnEvent.Subscribe(state, this,
 						canApplyParameters =>
-							canApplyParameters.AbilityState.Performer == state.Performer
-							&& canApplyParameters.Value < 0
-							&& !canApplyParameters.AMDCard.IsNull,
+							canApplyParameters.AbilityState.Performer == state.Performer && 
+							canApplyParameters.Value < 0 && 
+							!canApplyParameters.AMDCard.IsNull,
 						async applyParameters =>
 						{
 							applyParameters.SetValue(0);

--- a/Game/Content/Classes/Hierophant/Cards/Prayers/06_Penitence.cs
+++ b/Game/Content/Classes/Hierophant/Cards/Prayers/06_Penitence.cs
@@ -16,7 +16,9 @@ public class Penitence : HierophantPrayerCardModel<Penitence.CardTop, Penitence.
 				{
 					ScenarioEvents.AMDCardDrawnEvent.Subscribe(state, this,
 						canApplyParameters =>
-							canApplyParameters.AbilityState.Performer == state.Performer && canApplyParameters.Value < 0,
+							canApplyParameters.AbilityState.Performer == state.Performer
+							&& canApplyParameters.Value < 0
+							&& !canApplyParameters.AMDCard.IsNull,
 						async applyParameters =>
 						{
 							applyParameters.SetValue(0);
@@ -48,7 +50,9 @@ public class Penitence : HierophantPrayerCardModel<Penitence.CardTop, Penitence.
 				{
 					ScenarioEvents.AMDCardDrawnEvent.Subscribe(state, this,
 						canApplyParameters =>
-							state.Performer.EnemiesWith(canApplyParameters.AbilityState.Performer) && canApplyParameters.Value > 0,
+							state.Performer.EnemiesWith(canApplyParameters.AbilityState.Performer)
+							&& canApplyParameters.Value > 0
+							&& !canApplyParameters.AMDCard.IsCrit,
 						async applyParameters =>
 						{
 							applyParameters.SetValue(0);


### PR DESCRIPTION
Image provided for reference syntax. If Penitence should trigger for null or crit, it would use this syntax.

Note: The reference image is from FH. I am unfamiliar with any such references from GH1, and while an argument could be made that it was originally intended to negate nulls/crits, it has been updated to FH, so it stands to reason that it purposefully does not prevent nulls/crits.

Edit: [confirmation](https://discord.com/channels/728375347732807825/994033940740456568/1406379036564783154) that it is not intended to work on nulls/crits.

<img width="400" height="600" alt="image" src="https://github.com/user-attachments/assets/1433de4d-002d-429b-94d5-a5462b9c4072" />
