### PR TITLE
Disable AfterSufferDamageEvent when damage is 0

### DIFF
--- a/Game/Scripts/Scenario/Abilities/AbilityCmd.cs
+++ b/Game/Scripts/Scenario/Abilities/AbilityCmd.cs
@@ -113,9 +113,11 @@ public static class AbilityCmd
 			await KillOrExhaust(potentialAttackAbilityState, target);
 		}
 
-		ScenarioEvents.AfterSufferDamage.Parameters afterSufferDamageParameters =
+		if (finalDamage > 0)
+		{
 			await ScenarioEvents.AfterSufferDamageEvent.CreatePrompt(
 				new ScenarioEvents.AfterSufferDamage.Parameters(target, finalDamage, potentialAttackAbilityState, sufferDamageParameters), potentialAttackAbilityState?.Authority ?? target);
+		}
 
 		return finalDamage;
 	}


### PR DESCRIPTION
- Prevents certain abilities from triggering when they shouldn't, i.e. when no damage was taken.

Note: Removed assignment to variable since the variable was not used for anything.