### PR TITLE
[TSC-003] [Improvement] Add builders

### DIFF
--- a/Game/Content/Classes/Bombard/ProjectileAbility.cs
+++ b/Game/Content/Classes/Bombard/ProjectileAbility.cs
@@ -3,6 +3,9 @@ using System.Collections.Generic;
 using Fractural.Tasks;
 using Godot;
 
+/// <summary>
+/// A signature <see cref="ActiveAbility{T}"/> of the <see cref="BombardModel"/> class.
+/// </summary>
 public class ProjectileAbility : ActiveAbility<ProjectileAbility.State>
 {
 	public class State : ActiveAbilityState
@@ -15,20 +18,95 @@ public class ProjectileAbility : ActiveAbility<ProjectileAbility.State>
 		}
 	}
 
-	private readonly Func<Hex, List<Ability>> _getAbilities;
+	protected Func<Hex, List<Ability>> _getAbilities { get; set; }
+	public AbilityCardSide AbilityCardSide { get; protected set; }
 
-	public int Range { get; }
-	public int Targets { get; }
-	public AbilityCardSide AbilityCardSide { get; }
+	public int Range { get; protected set; }
+	public int Targets { get; protected set; } = 1;
+
+	/// <summary>
+	/// A builder extending <see cref="Ability{T}.AbstractBuilder{TBuilder, TAbility}"/> with setter methods
+	/// for values defined in ProjectileAbility. Enables inheritors of ProjectileAbility to further extend the builder.
+	/// </summary>
+	/// <typeparam name="TBuilder"></typeparam> Any builder extending this AbstractBuilder.
+	/// <typeparam name="TAbility"></typeparam> Any ability extending ProjectileAbility.
+	public new class AbstractBuilder<TBuilder, TAbility> : ActiveAbility<State>.AbstractBuilder<TBuilder, TAbility>,
+		AbstractBuilder<TBuilder, TAbility>.IGetAbilitiesStep,
+		AbstractBuilder<TBuilder, TAbility>.IAbilityCardSideStep,
+		AbstractBuilder<TBuilder, TAbility>.IRangeStep
+		where TBuilder : AbstractBuilder<TBuilder, TAbility>
+		where TAbility : ProjectileAbility, new()
+	{
+		
+		public interface IGetAbilitiesStep
+		{
+			IAbilityCardSideStep WithGetAbilities(Func<Hex, List<Ability>> getAbilities);
+		}
+		
+		public interface IAbilityCardSideStep
+		{
+			IRangeStep WithAbilityCardSide(AbilityCardSide abilityCardSide);
+		}
+		
+		public interface IRangeStep
+		{
+			TBuilder WithRange(int range);
+		}
+		
+		public IAbilityCardSideStep WithGetAbilities(Func<Hex, List<Ability>> getAbilities)
+		{
+			Obj._getAbilities = getAbilities;
+			return (TBuilder)this;
+		}
+
+		public IRangeStep WithAbilityCardSide(AbilityCardSide abilityCardSide)
+		{
+			Obj.AbilityCardSide = abilityCardSide;
+			return (TBuilder)this;
+		}
+
+		public TBuilder WithRange(int range)
+		{
+			Obj.Range = range;
+			return (TBuilder)this;
+		}
+
+		public TBuilder WithTargets(int targets)
+		{
+			Obj.Targets = targets;
+			return (TBuilder)this;
+		}
+	}
+
+	/// <summary>
+	/// A concrete implementation of the AbstractBuilder. Required to actually use the builder,
+	/// as abstract builders cannot be instantiated.
+	/// </summary>
+	public class ProjectileBuilder : AbstractBuilder<ProjectileBuilder, ProjectileAbility>
+	{
+		internal ProjectileBuilder() { }
+	}
+
+	/// <summary>
+	/// A convenience method that returns an instance of ProjectileBuilder.
+	/// </summary>
+	/// <returns></returns>
+	public static ProjectileBuilder.IGetAbilitiesStep Builder()
+	{
+		return new ProjectileBuilder();
+	}
+
+	public ProjectileAbility() { }
 
 	public ProjectileAbility(int range, Func<Hex, List<Ability>> getAbilities, AbilityCardSide abilityCardSide, int targets = 1,
 		Func<State, GDTask> onAbilityStarted = null, Func<State, GDTask> onAbilityEnded = null, Func<State, GDTask> onAbilityEndedPerformed = null,
 		ConditionalAbilityCheckDelegate conditionalAbilityCheck = null,
 		Func<State, string> getHintText = null,
-		List<ScenarioEvents.AbilityStarted.Subscription> abilityStartedSubscriptions = null,
-		List<ScenarioEvents.AbilityEnded.Subscription> abilityEndedSubscriptions = null,
+		List<ScenarioEvent<ScenarioEvents.AbilityStarted.Parameters>.Subscription> abilityStartedSubscriptions = null,
+		List<ScenarioEvent<ScenarioEvents.AbilityEnded.Parameters>.Subscription> abilityEndedSubscriptions = null,
 		List<ScenarioEvent<ScenarioEvents.AbilityPerformed.Parameters>.Subscription> abilityPerformedSubscriptions = null)
-		: base(onAbilityStarted, onAbilityEnded, onAbilityEndedPerformed, conditionalAbilityCheck, getHintText, abilityStartedSubscriptions, abilityEndedSubscriptions, abilityPerformedSubscriptions)
+		: base(onAbilityStarted, onAbilityEnded, onAbilityEndedPerformed, conditionalAbilityCheck, getHintText, abilityStartedSubscriptions,
+			abilityEndedSubscriptions, abilityPerformedSubscriptions)
 	{
 		_getAbilities = getAbilities;
 		Range = range;
@@ -47,7 +125,8 @@ public class ProjectileAbility : ActiveAbility<ProjectileAbility.State>
 
 			if(targetedHex != null)
 			{
-				BombardProjectileToken token = ResourceLoader.Load<PackedScene>("res://Content/Classes/Bombard/BombardProjectile.tscn").Instantiate<BombardProjectileToken>();
+				BombardProjectileToken token = ResourceLoader.Load<PackedScene>("res://Content/Classes/Bombard/BombardProjectile.tscn")
+					.Instantiate<BombardProjectileToken>();
 				GameController.Instance.Map.AddChild(token);
 				token.SetCardSide(AbilityCardSide);
 

--- a/Game/Content/Classes/Bombard/ProjectileAbility.cs
+++ b/Game/Content/Classes/Bombard/ProjectileAbility.cs
@@ -18,11 +18,11 @@ public class ProjectileAbility : ActiveAbility<ProjectileAbility.State>
 		}
 	}
 
-	protected Func<Hex, List<Ability>> _getAbilities { get; set; }
-	public AbilityCardSide AbilityCardSide { get; protected set; }
+	private Func<Hex, List<Ability>> _getAbilities;
+	public AbilityCardSide AbilityCardSide { get; private set; }
 
-	public int Range { get; protected set; }
-	public int Targets { get; protected set; } = 1;
+	public int Range { get; private set; }
+	public int Targets { get; private set; } = 1;
 
 	/// <summary>
 	/// A builder extending <see cref="Ability{T}.AbstractBuilder{TBuilder, TAbility}"/> with setter methods
@@ -37,22 +37,21 @@ public class ProjectileAbility : ActiveAbility<ProjectileAbility.State>
 		where TBuilder : AbstractBuilder<TBuilder, TAbility>
 		where TAbility : ProjectileAbility, new()
 	{
-		
 		public interface IGetAbilitiesStep
 		{
 			IAbilityCardSideStep WithGetAbilities(Func<Hex, List<Ability>> getAbilities);
 		}
-		
+
 		public interface IAbilityCardSideStep
 		{
 			IRangeStep WithAbilityCardSide(AbilityCardSide abilityCardSide);
 		}
-		
+
 		public interface IRangeStep
 		{
 			TBuilder WithRange(int range);
 		}
-		
+
 		public IAbilityCardSideStep WithGetAbilities(Func<Hex, List<Ability>> getAbilities)
 		{
 			Obj._getAbilities = getAbilities;

--- a/Game/Content/Classes/Bombard/PullSelfAbility.cs
+++ b/Game/Content/Classes/Bombard/PullSelfAbility.cs
@@ -2,13 +2,60 @@
 using System.Collections.Generic;
 using Fractural.Tasks;
 
+/// <summary>
+/// A forced movement <see cref="TargetedAbility{T, TSingleTargetState}"/> that moves the acting figure towards the target,
+/// ignoring most movement rules.
+/// </summary>
 public class PullSelfAbility : TargetedAbility<PullSelfAbility.State, SingleTargetState>
 {
 	public class State : TargetedAbilityState<SingleTargetState>
 	{
 	}
 
-	public int PullSelfValue { get; }
+	public int PullSelfValue { get; protected set; }
+	
+	/// <summary>
+	/// A builder extending <see cref="TargetedAbility{T, TSingleTargetState}.AbstractBuilder{TBuilder, TAbility}"/> with setter methods
+	/// for values defined in PullSelfAbility. Enables inheritors of PullSelfAbility to further extend the builder.
+	/// </summary>
+	/// <typeparam name="TBuilder"></typeparam> Any builder extending this AbstractBuilder.
+	/// <typeparam name="TAbility"></typeparam> Any ability extending PullSelfAbility.
+	public new abstract class AbstractBuilder<TBuilder, TAbility> : TargetedAbility<State, SingleTargetState>.AbstractBuilder<TBuilder, TAbility>,
+		AbstractBuilder<TBuilder, TAbility>.IPullPullSelfStep
+		where TBuilder : AbstractBuilder<TBuilder, TAbility>
+		where TAbility : PullSelfAbility, new()
+	{
+		public interface IPullPullSelfStep
+		{
+			TBuilder WithPullSelfValue(int pullSelfValue);
+		}
+		
+		public TBuilder WithPullSelfValue(int pullSelfValue)
+		{
+			Obj.PullSelfValue = pullSelfValue;
+			return (TBuilder)this;
+		}
+	}
+
+	/// <summary>
+	/// A concrete implementation of the AbstractBuilder. Required to actually use the builder,
+	/// as abstract builders cannot be instantiated.
+	/// </summary>
+	public class PullBuilder : AbstractBuilder<PullBuilder, PullSelfAbility>
+	{
+		internal PullBuilder() { }
+	}
+
+	/// <summary>
+	/// A convenience method that returns an instance of PullBuilder.
+	/// </summary>
+	/// <returns></returns>
+	public static PullBuilder.IPullPullSelfStep Builder()
+	{
+		return new PullBuilder();
+	}
+
+	public PullSelfAbility() { }
 
 	public PullSelfAbility(int pull, int targets = 1, int? range = null, RangeType? rangeType = null,
 		Target target = Target.Enemies,

--- a/Game/Content/Classes/Bombard/PullSelfAbility.cs
+++ b/Game/Content/Classes/Bombard/PullSelfAbility.cs
@@ -12,8 +12,8 @@ public class PullSelfAbility : TargetedAbility<PullSelfAbility.State, SingleTarg
 	{
 	}
 
-	public int PullSelfValue { get; protected set; }
-	
+	public int PullSelfValue { get; private set; }
+
 	/// <summary>
 	/// A builder extending <see cref="TargetedAbility{T, TSingleTargetState}.AbstractBuilder{TBuilder, TAbility}"/> with setter methods
 	/// for values defined in PullSelfAbility. Enables inheritors of PullSelfAbility to further extend the builder.
@@ -29,7 +29,7 @@ public class PullSelfAbility : TargetedAbility<PullSelfAbility.State, SingleTarg
 		{
 			TBuilder WithPullSelfValue(int pullSelfValue);
 		}
-		
+
 		public TBuilder WithPullSelfValue(int pullSelfValue)
 		{
 			Obj.PullSelfValue = pullSelfValue;
@@ -41,18 +41,18 @@ public class PullSelfAbility : TargetedAbility<PullSelfAbility.State, SingleTarg
 	/// A concrete implementation of the AbstractBuilder. Required to actually use the builder,
 	/// as abstract builders cannot be instantiated.
 	/// </summary>
-	public class PullBuilder : AbstractBuilder<PullBuilder, PullSelfAbility>
+	public class PullSelfBuilder : AbstractBuilder<PullSelfBuilder, PullSelfAbility>
 	{
-		internal PullBuilder() { }
+		internal PullSelfBuilder() { }
 	}
 
 	/// <summary>
 	/// A convenience method that returns an instance of PullBuilder.
 	/// </summary>
 	/// <returns></returns>
-	public static PullBuilder.IPullPullSelfStep Builder()
+	public static PullSelfBuilder.IPullPullSelfStep Builder()
 	{
-		return new PullBuilder();
+		return new PullSelfBuilder();
 	}
 
 	public PullSelfAbility() { }
@@ -81,6 +81,7 @@ public class PullSelfAbility : TargetedAbility<PullSelfAbility.State, SingleTarg
 	{
 		await base.AfterConditionsApplied(abilityState, target);
 
-		await PushPull(abilityState, target.Hex, abilityState.Performer, PullSelfValue, false, () => $"Select a path to {Icons.HintText(Icons.Pull)}{PullSelfValue} self toward target");
+		await PushPull(abilityState, target.Hex, abilityState.Performer, PullSelfValue, false,
+			() => $"Select a path to {Icons.HintText(Icons.Pull)}{PullSelfValue} self toward target");
 	}
 }

--- a/Game/Scripts/Models/Abilities/Ability.cs
+++ b/Game/Scripts/Models/Abilities/Ability.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using Fractural.Tasks;
 
@@ -10,17 +10,111 @@ public abstract class Ability<T> : Ability
 {
 	public delegate GDTask<bool> ConditionalAbilityCheckDelegate(T abilityState);
 
-	private readonly Func<T, GDTask> _onAbilityStarted;
-	private readonly Func<T, GDTask> _onAbilityEnded;
-	private readonly Func<T, GDTask> _onAbilityEndedPerformed;
+	private Func<T, GDTask> _onAbilityStarted { get; set; }
+	private Func<T, GDTask> _onAbilityEnded { get; set; }
+	private Func<T, GDTask> _onAbilityEndedPerformed { get; set; }
 
-	private readonly ConditionalAbilityCheckDelegate _conditionalAbilityCheck;
+	private ConditionalAbilityCheckDelegate ConditionalAbilityCheck { get; set; }
 
-	public List<ScenarioEvent<ScenarioEvents.AbilityStarted.Parameters>.Subscription> AbilityStartedSubscriptions { get; }
-	public List<ScenarioEvent<ScenarioEvents.AbilityEnded.Parameters>.Subscription> AbilityEndedSubscriptions { get; }
-	public List<ScenarioEvent<ScenarioEvents.AbilityPerformed.Parameters>.Subscription> AbilityPerformedSubscriptions { get; }
+	public List<ScenarioEvent<ScenarioEvents.AbilityStarted.Parameters>.Subscription> AbilityStartedSubscriptions { get; protected set; } = [];
+	public List<ScenarioEvent<ScenarioEvents.AbilityEnded.Parameters>.Subscription> AbilityEndedSubscriptions { get; protected set; } = [];
+	public List<ScenarioEvent<ScenarioEvents.AbilityPerformed.Parameters>.Subscription> AbilityPerformedSubscriptions { get; protected set; } = [];
 
-	protected Ability(Func<T, GDTask> onAbilityStarted, Func<T, GDTask> onAbilityEnded, Func<T, GDTask> onAbilityEndedPerformed,
+	private bool CanPerformWhileStunned { get; set; }
+
+	/// <summary>
+	/// A builder utilizing generics, which enables inheritors to extend the builder as well.
+	/// Simplifies adding new properties, which will automatically be propagated to inheritor builders.
+	/// </summary>
+	/// <typeparam name="TBuilder"></typeparam> Any builder extending this AbstractBuilder.
+	/// <typeparam name="TAbility"></typeparam> Any Ability extending Ability.
+	public abstract class AbstractBuilder<TBuilder, TAbility>
+		where TBuilder : AbstractBuilder<TBuilder, TAbility>
+		where TAbility : Ability<T>, new()
+	{
+		protected readonly TAbility Obj = new TAbility();
+
+		public TBuilder WithOnAbilityStarted(Func<T, GDTask> onAbilityStarted)
+		{
+			Obj._onAbilityStarted = onAbilityStarted;
+			return (TBuilder)this;
+		}
+
+		public TBuilder WithOnAbilityEnded(Func<T, GDTask> onAbilityEnded)
+		{
+			Obj._onAbilityEnded = onAbilityEnded;
+			return (TBuilder)this;
+		}
+
+		public TBuilder WithOnAbilityEndedPerformed(Func<T, GDTask> onAbilityEndedPerformed)
+		{
+			Obj._onAbilityEndedPerformed = onAbilityEndedPerformed;
+			return (TBuilder)this;
+		}
+
+		public TBuilder WithConditionalAbilityCheck(ConditionalAbilityCheckDelegate conditionalAbilityCheck)
+		{
+			Obj.ConditionalAbilityCheck = conditionalAbilityCheck;
+			return (TBuilder)this;
+		}
+
+		public TBuilder WithAbilityStartedSubscription(
+			ScenarioEvent<ScenarioEvents.AbilityStarted.Parameters>.Subscription abilityStartedSubscription)
+		{
+			Obj.AbilityStartedSubscriptions.Add(abilityStartedSubscription);
+			return (TBuilder)this;
+		}
+
+		public TBuilder WithAbilityStartedSubscriptions(
+			List<ScenarioEvent<ScenarioEvents.AbilityStarted.Parameters>.Subscription> abilityStartedSubscriptions)
+		{
+			Obj.AbilityStartedSubscriptions = abilityStartedSubscriptions;
+			return (TBuilder)this;
+		}
+
+		public TBuilder WithAbilityEndedSubscription(ScenarioEvent<ScenarioEvents.AbilityEnded.Parameters>.Subscription abilityEndedSubscription)
+		{
+			Obj.AbilityEndedSubscriptions.Add(abilityEndedSubscription);
+			return (TBuilder)this;
+		}
+
+		public TBuilder WithAbilityEndedSubscriptions(
+			List<ScenarioEvent<ScenarioEvents.AbilityEnded.Parameters>.Subscription> abilityEndedSubscriptions)
+		{
+			Obj.AbilityEndedSubscriptions = abilityEndedSubscriptions;
+			return (TBuilder)this;
+		}
+
+		public TBuilder WithAbilityPerformedSubscription(
+			ScenarioEvent<ScenarioEvents.AbilityPerformed.Parameters>.Subscription abilityPerformedSubscription)
+		{
+			Obj.AbilityPerformedSubscriptions.Add(abilityPerformedSubscription);
+			return (TBuilder)this;
+		}
+
+		public TBuilder WithAbilityPerformedSubscriptions(
+			List<ScenarioEvent<ScenarioEvents.AbilityPerformed.Parameters>.Subscription> abilityPerformedSubscriptions)
+		{
+			Obj.AbilityPerformedSubscriptions = abilityPerformedSubscriptions;
+			return (TBuilder)this;
+		}
+
+		public TBuilder WithCanPerformWhileStunned()
+		{
+			Obj.CanPerformWhileStunned = true;
+			return (TBuilder)this;
+		}
+
+		public virtual TAbility Build()
+		{
+			return Obj;
+		}
+	}
+
+	protected Ability() { }
+
+	protected Ability(Func<T, GDTask> onAbilityStarted, Func<T, GDTask> onAbilityEnded,
+		Func<T, GDTask> onAbilityEndedPerformed,
 		ConditionalAbilityCheckDelegate conditionalAbilityCheck,
 		List<ScenarioEvent<ScenarioEvents.AbilityStarted.Parameters>.Subscription> abilityStartedSubscriptions,
 		List<ScenarioEvent<ScenarioEvents.AbilityEnded.Parameters>.Subscription> abilityEndedSubscriptions,
@@ -30,7 +124,7 @@ public abstract class Ability<T> : Ability
 		_onAbilityEnded = onAbilityEnded;
 		_onAbilityEndedPerformed = onAbilityEndedPerformed;
 
-		_conditionalAbilityCheck = conditionalAbilityCheck;
+		ConditionalAbilityCheck = conditionalAbilityCheck;
 
 		AbilityStartedSubscriptions = abilityStartedSubscriptions;
 		AbilityEndedSubscriptions = abilityEndedSubscriptions;
@@ -69,9 +163,9 @@ public abstract class Ability<T> : Ability
 			await _onAbilityStarted(abilityState);
 		}
 
-		if(_conditionalAbilityCheck != null)
+		if(ConditionalAbilityCheck != null)
 		{
-			if(!await _conditionalAbilityCheck(abilityState))
+			if(!await ConditionalAbilityCheck(abilityState))
 			{
 				abilityState.SetBlocked();
 				return;

--- a/Game/Scripts/Models/Abilities/Ability.cs
+++ b/Game/Scripts/Models/Abilities/Ability.cs
@@ -20,8 +20,6 @@ public abstract class Ability<T> : Ability
 	public List<ScenarioEvent<ScenarioEvents.AbilityEnded.Parameters>.Subscription> AbilityEndedSubscriptions { get; protected set; } = [];
 	public List<ScenarioEvent<ScenarioEvents.AbilityPerformed.Parameters>.Subscription> AbilityPerformedSubscriptions { get; protected set; } = [];
 
-	private bool CanPerformWhileStunned { get; set; }
-
 	/// <summary>
 	/// A builder utilizing generics, which enables inheritors to extend the builder as well.
 	/// Simplifies adding new properties, which will automatically be propagated to inheritor builders.
@@ -96,12 +94,6 @@ public abstract class Ability<T> : Ability
 			List<ScenarioEvent<ScenarioEvents.AbilityPerformed.Parameters>.Subscription> abilityPerformedSubscriptions)
 		{
 			Obj.AbilityPerformedSubscriptions = abilityPerformedSubscriptions;
-			return (TBuilder)this;
-		}
-
-		public TBuilder WithCanPerformWhileStunned()
-		{
-			Obj.CanPerformWhileStunned = true;
 			return (TBuilder)this;
 		}
 

--- a/Game/Scripts/Models/Abilities/Ability.cs
+++ b/Game/Scripts/Models/Abilities/Ability.cs
@@ -10,15 +10,15 @@ public abstract class Ability<T> : Ability
 {
 	public delegate GDTask<bool> ConditionalAbilityCheckDelegate(T abilityState);
 
-	private Func<T, GDTask> _onAbilityStarted { get; set; }
-	private Func<T, GDTask> _onAbilityEnded { get; set; }
-	private Func<T, GDTask> _onAbilityEndedPerformed { get; set; }
+	private Func<T, GDTask> _onAbilityStarted;
+	private Func<T, GDTask> _onAbilityEnded;
+	private Func<T, GDTask> _onAbilityEndedPerformed;
 
-	private ConditionalAbilityCheckDelegate ConditionalAbilityCheck { get; set; }
+	private ConditionalAbilityCheckDelegate _conditionalAbilityCheck;
 
-	public List<ScenarioEvent<ScenarioEvents.AbilityStarted.Parameters>.Subscription> AbilityStartedSubscriptions { get; protected set; } = [];
-	public List<ScenarioEvent<ScenarioEvents.AbilityEnded.Parameters>.Subscription> AbilityEndedSubscriptions { get; protected set; } = [];
-	public List<ScenarioEvent<ScenarioEvents.AbilityPerformed.Parameters>.Subscription> AbilityPerformedSubscriptions { get; protected set; } = [];
+	public List<ScenarioEvent<ScenarioEvents.AbilityStarted.Parameters>.Subscription> AbilityStartedSubscriptions { get; private set; } = [];
+	public List<ScenarioEvent<ScenarioEvents.AbilityEnded.Parameters>.Subscription> AbilityEndedSubscriptions { get; private set; } = [];
+	public List<ScenarioEvent<ScenarioEvents.AbilityPerformed.Parameters>.Subscription> AbilityPerformedSubscriptions { get; private set; } = [];
 
 	/// <summary>
 	/// A builder utilizing generics, which enables inheritors to extend the builder as well.
@@ -52,46 +52,41 @@ public abstract class Ability<T> : Ability
 
 		public TBuilder WithConditionalAbilityCheck(ConditionalAbilityCheckDelegate conditionalAbilityCheck)
 		{
-			Obj.ConditionalAbilityCheck = conditionalAbilityCheck;
+			Obj._conditionalAbilityCheck = conditionalAbilityCheck;
 			return (TBuilder)this;
 		}
 
-		public TBuilder WithAbilityStartedSubscription(
-			ScenarioEvent<ScenarioEvents.AbilityStarted.Parameters>.Subscription abilityStartedSubscription)
+		public TBuilder WithAbilityStartedSubscription(ScenarioEvents.AbilityStarted.Subscription abilityStartedSubscription)
 		{
 			Obj.AbilityStartedSubscriptions.Add(abilityStartedSubscription);
 			return (TBuilder)this;
 		}
 
-		public TBuilder WithAbilityStartedSubscriptions(
-			List<ScenarioEvent<ScenarioEvents.AbilityStarted.Parameters>.Subscription> abilityStartedSubscriptions)
+		public TBuilder WithAbilityStartedSubscriptions(List<ScenarioEvents.AbilityStarted.Subscription> abilityStartedSubscriptions)
 		{
 			Obj.AbilityStartedSubscriptions = abilityStartedSubscriptions;
 			return (TBuilder)this;
 		}
 
-		public TBuilder WithAbilityEndedSubscription(ScenarioEvent<ScenarioEvents.AbilityEnded.Parameters>.Subscription abilityEndedSubscription)
+		public TBuilder WithAbilityEndedSubscription(ScenarioEvents.AbilityEnded.Subscription abilityEndedSubscription)
 		{
 			Obj.AbilityEndedSubscriptions.Add(abilityEndedSubscription);
 			return (TBuilder)this;
 		}
 
-		public TBuilder WithAbilityEndedSubscriptions(
-			List<ScenarioEvent<ScenarioEvents.AbilityEnded.Parameters>.Subscription> abilityEndedSubscriptions)
+		public TBuilder WithAbilityEndedSubscriptions(List<ScenarioEvents.AbilityEnded.Subscription> abilityEndedSubscriptions)
 		{
 			Obj.AbilityEndedSubscriptions = abilityEndedSubscriptions;
 			return (TBuilder)this;
 		}
 
-		public TBuilder WithAbilityPerformedSubscription(
-			ScenarioEvent<ScenarioEvents.AbilityPerformed.Parameters>.Subscription abilityPerformedSubscription)
+		public TBuilder WithAbilityPerformedSubscription(ScenarioEvents.AbilityPerformed.Subscription abilityPerformedSubscription)
 		{
 			Obj.AbilityPerformedSubscriptions.Add(abilityPerformedSubscription);
 			return (TBuilder)this;
 		}
 
-		public TBuilder WithAbilityPerformedSubscriptions(
-			List<ScenarioEvent<ScenarioEvents.AbilityPerformed.Parameters>.Subscription> abilityPerformedSubscriptions)
+		public TBuilder WithAbilityPerformedSubscriptions(List<ScenarioEvents.AbilityPerformed.Subscription> abilityPerformedSubscriptions)
 		{
 			Obj.AbilityPerformedSubscriptions = abilityPerformedSubscriptions;
 			return (TBuilder)this;
@@ -116,7 +111,7 @@ public abstract class Ability<T> : Ability
 		_onAbilityEnded = onAbilityEnded;
 		_onAbilityEndedPerformed = onAbilityEndedPerformed;
 
-		ConditionalAbilityCheck = conditionalAbilityCheck;
+		_conditionalAbilityCheck = conditionalAbilityCheck;
 
 		AbilityStartedSubscriptions = abilityStartedSubscriptions;
 		AbilityEndedSubscriptions = abilityEndedSubscriptions;
@@ -155,9 +150,9 @@ public abstract class Ability<T> : Ability
 			await _onAbilityStarted(abilityState);
 		}
 
-		if(ConditionalAbilityCheck != null)
+		if(_conditionalAbilityCheck != null)
 		{
-			if(!await ConditionalAbilityCheck(abilityState))
+			if(!await _conditionalAbilityCheck(abilityState))
 			{
 				abilityState.SetBlocked();
 				return;

--- a/Game/Scripts/Models/Abilities/ActiveAbility.cs
+++ b/Game/Scripts/Models/Abilities/ActiveAbility.cs
@@ -22,25 +22,52 @@ public abstract class ActiveAbilityState : AbilityState
 	}
 }
 
+/// <summary>
+/// An <see cref="Ability{T}"/> that has some sort of persistent effect.
+/// </summary>
 public abstract class ActiveAbility<T> : Ability<T> where T : ActiveAbilityState, new()
 {
-	private Func<T, string> _getHintText;
+	private Func<T, string> GetHintText { get; set; }
+
+	public new abstract class AbstractBuilder<TBuilder, TAbility> : Ability<T>.AbstractBuilder<TBuilder, TAbility>
+		where TBuilder : AbstractBuilder<TBuilder, TAbility>
+		where TAbility : ActiveAbility<T>, new()
+	{
+		private Func<T, string> _getHintText;
+		public TBuilder WithGetHintText(Func<T, string> getHintText)
+		{
+			_getHintText = getHintText;
+			Obj.GetHintText = getHintText;
+			return (TBuilder)this;
+		}
+
+		/// <summary>
+		/// Overriding so we can set default values.
+		/// </summary>
+		public override TAbility Build()
+		{
+			Obj.GetHintText = _getHintText ?? Obj.DefaultHintText;
+			return base.Build();
+		}
+	}
 
 	protected ActiveAbility(
 		Func<T, GDTask> onAbilityStarted = null, Func<T, GDTask> onAbilityEnded = null, Func<T, GDTask> onAbilityEndedPerformed = null,
 		ConditionalAbilityCheckDelegate conditionalAbilityCheck = null,
 		Func<T, string> getHintText = null,
-		List<ScenarioEvents.AbilityStarted.Subscription> abilityStartedSubscriptions = null,
-		List<ScenarioEvents.AbilityEnded.Subscription> abilityEndedSubscriptions = null,
+		List<ScenarioEvent<ScenarioEvents.AbilityStarted.Parameters>.Subscription> abilityStartedSubscriptions = null,
+		List<ScenarioEvent<ScenarioEvents.AbilityEnded.Parameters>.Subscription> abilityEndedSubscriptions = null,
 		List<ScenarioEvent<ScenarioEvents.AbilityPerformed.Parameters>.Subscription> abilityPerformedSubscriptions = null)
-		: base(onAbilityStarted, onAbilityEnded, onAbilityEndedPerformed, conditionalAbilityCheck, abilityStartedSubscriptions, abilityEndedSubscriptions, abilityPerformedSubscriptions)
+		: base(onAbilityStarted, onAbilityEnded, onAbilityEndedPerformed, conditionalAbilityCheck, abilityStartedSubscriptions,
+			abilityEndedSubscriptions, abilityPerformedSubscriptions)
 	{
-		_getHintText = getHintText ?? DefaultHintText;
+		GetHintText = getHintText ?? DefaultHintText;
 	}
 
 	protected async GDTask AskConfirmAndActivate(T abilityState)
 	{
-		ConfirmPrompt.Answer confirmAnswer = await PromptManager.Prompt(new ConfirmPrompt(null, () => _getHintText(abilityState)), abilityState.Authority);
+		ConfirmPrompt.Answer confirmAnswer =
+			await PromptManager.Prompt(new ConfirmPrompt(null, () => GetHintText(abilityState)), abilityState.Authority);
 		if(confirmAnswer.Confirmed)
 		{
 			await Activate(abilityState);

--- a/Game/Scripts/Models/Abilities/ActiveAbility.cs
+++ b/Game/Scripts/Models/Abilities/ActiveAbility.cs
@@ -23,21 +23,22 @@ public abstract class ActiveAbilityState : AbilityState
 }
 
 /// <summary>
-/// An <see cref="Ability{T}"/> that has some sort of persistent effect.
+/// An <see cref="Ability{T}"/> that has some sort of active effect that lasts for some duration.
 /// </summary>
 public abstract class ActiveAbility<T> : Ability<T> where T : ActiveAbilityState, new()
 {
-	private Func<T, string> GetHintText { get; set; }
+	private Func<T, string> _getHintText;
 
 	public new abstract class AbstractBuilder<TBuilder, TAbility> : Ability<T>.AbstractBuilder<TBuilder, TAbility>
 		where TBuilder : AbstractBuilder<TBuilder, TAbility>
 		where TAbility : ActiveAbility<T>, new()
 	{
 		private Func<T, string> _getHintText;
+
 		public TBuilder WithGetHintText(Func<T, string> getHintText)
 		{
 			_getHintText = getHintText;
-			Obj.GetHintText = getHintText;
+			Obj._getHintText = getHintText;
 			return (TBuilder)this;
 		}
 
@@ -46,7 +47,7 @@ public abstract class ActiveAbility<T> : Ability<T> where T : ActiveAbilityState
 		/// </summary>
 		public override TAbility Build()
 		{
-			Obj.GetHintText = _getHintText ?? Obj.DefaultHintText;
+			Obj._getHintText = _getHintText ?? Obj.DefaultHintText;
 			return base.Build();
 		}
 	}
@@ -61,13 +62,13 @@ public abstract class ActiveAbility<T> : Ability<T> where T : ActiveAbilityState
 		: base(onAbilityStarted, onAbilityEnded, onAbilityEndedPerformed, conditionalAbilityCheck, abilityStartedSubscriptions,
 			abilityEndedSubscriptions, abilityPerformedSubscriptions)
 	{
-		GetHintText = getHintText ?? DefaultHintText;
+		_getHintText = getHintText ?? DefaultHintText;
 	}
 
 	protected async GDTask AskConfirmAndActivate(T abilityState)
 	{
 		ConfirmPrompt.Answer confirmAnswer =
-			await PromptManager.Prompt(new ConfirmPrompt(null, () => GetHintText(abilityState)), abilityState.Authority);
+			await PromptManager.Prompt(new ConfirmPrompt(null, () => _getHintText(abilityState)), abilityState.Authority);
 		if(confirmAnswer.Confirmed)
 		{
 			await Activate(abilityState);

--- a/Game/Scripts/Models/Abilities/AttackAbility.cs
+++ b/Game/Scripts/Models/Abilities/AttackAbility.cs
@@ -6,6 +6,9 @@ using GTweens.Builders;
 using GTweens.Easings;
 using GTweensGodot.Extensions;
 
+/// <summary>
+/// A <see cref="TargetedAbility{T, TSingleTargetState}"/> that creates an attack on a given target.
+/// </summary>
 public class AttackAbility : TargetedAbility<AttackAbility.State, SingleTargetState>
 {
 	public class State : TargetedAbilityState<SingleTargetState>
@@ -71,14 +74,131 @@ public class AttackAbility : TargetedAbility<AttackAbility.State, SingleTargetSt
 		}
 	}
 
-	public DynamicInt<State> Damage { get; }
-	public DynamicInt<State> Pierce { get; }
-	public bool HasAdvantage { get; }
-	public bool HasDisadvantage { get; }
+	public DynamicInt<State> Damage { get; protected set; }
+	public DynamicInt<State> Pierce { get; protected set; } = 0;
+	public bool HasAdvantage { get; protected set; }
+	public bool HasDisadvantage { get; protected set; }
 
-	public List<ScenarioEvents.DuringAttack.Subscription> DuringAttackSubscriptions { get; }
-	public List<ScenarioEvents.AttackAfterTargetConfirmed.Subscription> AfterTargetConfirmedSubscriptions { get; }
-	public List<ScenarioEvents.AfterAttackPerformed.Subscription> AfterAttackPerformedSubscriptions { get; }
+	public List<ScenarioEvent<ScenarioEvents.DuringAttack.Parameters>.Subscription> DuringAttackSubscriptions { get; protected set; } = [];
+	public List<ScenarioEvent<ScenarioEvents.AttackAfterTargetConfirmed.Parameters>.Subscription>
+		AfterTargetConfirmedSubscriptions { get; protected set; } = [];
+	public List<ScenarioEvent<ScenarioEvents.AfterAttackPerformed.Parameters>.Subscription>
+		AfterAttackPerformedSubscriptions { get; protected set; } = [];
+
+	/// <summary>
+	/// A builder extending <see cref="TargetedAbility{T, TSingleTargetState}.AbstractBuilder{TBuilder, TAbility}"/> with setter methods
+	/// for values defined in AttackAbility. Enables inheritors of AttackAbility to further extend the builder.
+	/// </summary>
+	/// <typeparam name="TBuilder"></typeparam> Any builder extending this AbstractBuilder.
+	/// <typeparam name="TAbility"></typeparam> Any ability extending AttackAbility.
+	public new class AbstractBuilder<TBuilder, TAbility> : TargetedAbility<State, SingleTargetState>.AbstractBuilder<TBuilder, TAbility>,
+		AbstractBuilder<TBuilder, TAbility>.IDamageStep
+		where TBuilder : AbstractBuilder<TBuilder, TAbility>
+		where TAbility : AttackAbility, new()
+	{
+
+		public interface IDamageStep
+		{
+			TBuilder WithDamage(DynamicInt<State> damage);
+		}
+
+		public TBuilder WithDamage(DynamicInt<State> damage)
+		{
+			Obj.Damage = damage;
+			return (TBuilder)this;
+		}
+
+		public TBuilder WithPierce(DynamicInt<State> pierce)
+		{
+			Obj.Pierce = pierce;
+			return (TBuilder)this;
+		}
+
+		public TBuilder WithAdvantage()
+		{
+			Obj.HasAdvantage = true;
+			return (TBuilder)this;
+		}
+
+		public TBuilder WithHasAdvantage(bool advantage)
+		{
+			Obj.HasAdvantage = advantage;
+			return (TBuilder)this;
+		}
+
+		public TBuilder WithDisadvantage()
+		{
+			Obj.HasDisadvantage = true;
+			return (TBuilder)this;
+		}
+
+		public TBuilder WithHasDisadvantage(bool disadvantage)
+		{
+			Obj.HasDisadvantage = disadvantage;
+			return (TBuilder)this;
+		}
+
+		public TBuilder WithDuringAttackSubscription(ScenarioEvent<ScenarioEvents.DuringAttack.Parameters>.Subscription movementSubscription)
+		{
+			Obj.DuringAttackSubscriptions.Add(movementSubscription);
+			return (TBuilder)this;
+		}
+
+		public TBuilder WithDuringAttackSubscriptions(
+			List<ScenarioEvent<ScenarioEvents.DuringAttack.Parameters>.Subscription> movementSubscriptions)
+		{
+			Obj.DuringAttackSubscriptions = movementSubscriptions;
+			return (TBuilder)this;
+		}
+
+		public TBuilder WithAfterTargetConfirmedSubscription(
+			ScenarioEvent<ScenarioEvents.AttackAfterTargetConfirmed.Parameters>.Subscription afterTargetConfirmedSubscription)
+		{
+			Obj.AfterTargetConfirmedSubscriptions.Add(afterTargetConfirmedSubscription);
+			return (TBuilder)this;
+		}
+
+		public TBuilder WithAfterTargetConfirmedSubscriptions(
+			List<ScenarioEvent<ScenarioEvents.AttackAfterTargetConfirmed.Parameters>.Subscription> afterTargetConfirmedSubscriptions)
+		{
+			Obj.AfterTargetConfirmedSubscriptions = afterTargetConfirmedSubscriptions;
+			return (TBuilder)this;
+		}
+
+		public TBuilder WithAfterAttackPerformedSubscription(
+			ScenarioEvent<ScenarioEvents.AfterAttackPerformed.Parameters>.Subscription afterAttackPerformedSubscription)
+		{
+			Obj.AfterAttackPerformedSubscriptions.Add(afterAttackPerformedSubscription);
+			return (TBuilder)this;
+		}
+
+		public TBuilder WithAfterAttackPerformedSubscriptions(
+			List<ScenarioEvent<ScenarioEvents.AfterAttackPerformed.Parameters>.Subscription> afterAttackPerformedSubscriptions)
+		{
+			Obj.AfterAttackPerformedSubscriptions = afterAttackPerformedSubscriptions;
+			return (TBuilder)this;
+		}
+	}
+
+	/// <summary>
+	/// A concrete implementation of the AbstractBuilder. Required to actually use the builder,
+	/// as abstract builders cannot be instantiated.
+	/// </summary>
+	public class AttackBuilder : AbstractBuilder<AttackBuilder, AttackAbility>
+	{
+		internal AttackBuilder() { }
+	}
+
+	/// <summary>
+	/// A convenience method that returns an instance of AttackBuilder.
+	/// </summary>
+	/// <returns></returns>
+	public static AbstractBuilder<AttackBuilder, AttackAbility>.IDamageStep Builder()
+	{
+		return new AttackBuilder();
+	}
+
+	public AttackAbility() { }
 
 	public AttackAbility(DynamicInt<State> value, int targets = 1, int? range = null, RangeType? rangeType = null,
 		Target target = Target.Enemies,
@@ -90,11 +210,11 @@ public class AttackAbility : TargetedAbility<AttackAbility.State, SingleTargetSt
 		Func<State, GDTask> onAbilityStarted = null, Func<State, GDTask> onAbilityEnded = null, Func<State, GDTask> onAbilityEndedPerformed = null,
 		ConditionalAbilityCheckDelegate conditionalAbilityCheck = null,
 		Func<State, string> getTargetingHintText = null,
-		List<ScenarioEvents.DuringAttack.Subscription> duringAttackSubscriptions = null,
-		List<ScenarioEvents.AttackAfterTargetConfirmed.Subscription> afterTargetConfirmedSubscriptions = null,
-		List<ScenarioEvents.AfterAttackPerformed.Subscription> afterAttackPerformedSubscriptions = null,
-		List<ScenarioEvents.AbilityStarted.Subscription> abilityStartedSubscriptions = null,
-		List<ScenarioEvents.AbilityEnded.Subscription> abilityEndedSubscriptions = null,
+		List<ScenarioEvent<ScenarioEvents.DuringAttack.Parameters>.Subscription> duringAttackSubscriptions = null,
+		List<ScenarioEvent<ScenarioEvents.AttackAfterTargetConfirmed.Parameters>.Subscription> afterTargetConfirmedSubscriptions = null,
+		List<ScenarioEvent<ScenarioEvents.AfterAttackPerformed.Parameters>.Subscription> afterAttackPerformedSubscriptions = null,
+		List<ScenarioEvent<ScenarioEvents.AbilityStarted.Parameters>.Subscription> abilityStartedSubscriptions = null,
+		List<ScenarioEvent<ScenarioEvents.AbilityEnded.Parameters>.Subscription> abilityEndedSubscriptions = null,
 		List<ScenarioEvent<ScenarioEvents.AbilityPerformed.Parameters>.Subscription> abilityPerformedSubscriptions = null)
 		: base(targets, range, rangeType, target,
 			requiresLineOfSight, mandatory, targetHex, aoePattern, push, pull, conditions,
@@ -169,7 +289,8 @@ public class AttackAbility : TargetedAbility<AttackAbility.State, SingleTargetSt
 
 	protected override async GDTask AfterTargetConfirmedBeforeConditionsApplied(State abilityState, Figure target)
 	{
-		bool rangeDisadvantage = abilityState.SingleTargetRangeType == RangeType.Range && RangeHelper.Distance(abilityState.Performer.Hex, target.Hex) == 1;
+		bool rangeDisadvantage = abilityState.SingleTargetRangeType == RangeType.Range &&
+		                         RangeHelper.Distance(abilityState.Performer.Hex, target.Hex) == 1;
 		if(rangeDisadvantage)
 		{
 			abilityState.SingleTargetSetHasDisadvantage();

--- a/Game/Scripts/Models/Abilities/AttackAbility.cs
+++ b/Game/Scripts/Models/Abilities/AttackAbility.cs
@@ -7,7 +7,7 @@ using GTweens.Easings;
 using GTweensGodot.Extensions;
 
 /// <summary>
-/// A <see cref="TargetedAbility{T, TSingleTargetState}"/> that creates an attack on a given target.
+/// A <see cref="TargetedAbility{T, TSingleTargetState}"/> that allows a figure to attack other figures.
 /// </summary>
 public class AttackAbility : TargetedAbility<AttackAbility.State, SingleTargetState>
 {
@@ -80,8 +80,10 @@ public class AttackAbility : TargetedAbility<AttackAbility.State, SingleTargetSt
 	public bool HasDisadvantage { get; protected set; }
 
 	public List<ScenarioEvent<ScenarioEvents.DuringAttack.Parameters>.Subscription> DuringAttackSubscriptions { get; protected set; } = [];
+
 	public List<ScenarioEvent<ScenarioEvents.AttackAfterTargetConfirmed.Parameters>.Subscription>
 		AfterTargetConfirmedSubscriptions { get; protected set; } = [];
+
 	public List<ScenarioEvent<ScenarioEvents.AfterAttackPerformed.Parameters>.Subscription>
 		AfterAttackPerformedSubscriptions { get; protected set; } = [];
 
@@ -96,7 +98,6 @@ public class AttackAbility : TargetedAbility<AttackAbility.State, SingleTargetSt
 		where TBuilder : AbstractBuilder<TBuilder, TAbility>
 		where TAbility : AttackAbility, new()
 	{
-
 		public interface IDamageStep
 		{
 			TBuilder WithDamage(DynamicInt<State> damage);

--- a/Game/Scripts/Models/Abilities/ConditionAbility.cs
+++ b/Game/Scripts/Models/Abilities/ConditionAbility.cs
@@ -2,13 +2,71 @@
 using System.Collections.Generic;
 using Fractural.Tasks;
 
+/// <summary>
+/// A <see cref="TargetedAbility{T, TSingleTargetState}"/> that applies at least one condition to a figure.
+/// </summary>
 public class ConditionAbility : TargetedAbility<ConditionAbility.State, SingleTargetState>
 {
 	public class State : TargetedAbilityState<SingleTargetState>
 	{
 	}
 
-	public List<ScenarioEvent<ScenarioEvents.ConditionAfterTargetConfirmed.Parameters>.Subscription> AfterTargetConfirmedSubscriptions { get; }
+	public List<ScenarioEvent<ScenarioEvents.ConditionAfterTargetConfirmed.Parameters>.Subscription>
+		AfterTargetConfirmedSubscriptions { get; protected set; } = [];
+
+	/// <summary>
+	/// A builder extending <see cref="TargetedAbility{T, TSingleTargetState}.AbstractBuilder{TBuilder, TAbility}"/> with setter methods
+	/// for values defined in ConditionAbility Enables inheritors of ConditionAbility to further extend the builder.
+	/// </summary>
+	/// <typeparam name="TBuilder"></typeparam> Any builder extending this AbstractBuilder.
+	/// <typeparam name="TAbility"></typeparam> Any ability extending ConditionAbility
+	public new abstract class AbstractBuilder<TBuilder, TAbility> : TargetedAbility<State, SingleTargetState>.AbstractBuilder<TBuilder, TAbility>,
+		AbstractBuilder<TBuilder, TAbility>.IConditionsStep
+		where TBuilder : AbstractBuilder<TBuilder, TAbility>
+		where TAbility : ConditionAbility, new()
+	{
+		public interface IConditionsStep
+		{
+			TBuilder WithConditions(params ConditionModel[] conditions);
+		}
+
+		public TBuilder WithConditions(params ConditionModel[] conditions)
+		{
+			Obj.Conditions = conditions;
+			return (TBuilder)this;
+		}
+
+		/// <summary>
+		/// Overriding so we can set default values.
+		/// </summary>
+		public override TAbility Build()
+		{
+			// TODO varadski 21.08.2025: I would maybe rather throw an exception if there are no conditions; should be mandatory for ConditionAbility
+			Obj.Target = _target ?? ((Obj.Conditions.Length > 0 && Obj.Conditions[0].IsPositive) ? Target.SelfOrAllies : Target.Enemies);
+			return base.Build();
+		}
+
+	}
+
+	/// <summary>
+	/// A concrete implementation of the AbstractBuilder. Required to actually use the builder,
+	/// as abstract builders cannot be instantiated.
+	/// </summary>
+	public class ConditionBuilder : AbstractBuilder<ConditionBuilder, ConditionAbility>
+	{
+		internal ConditionBuilder() { }
+	}
+
+	/// <summary>
+	/// A convenience method that returns an instance of ConditionBuilder.
+	/// </summary>
+	/// <returns></returns>
+	public static ConditionBuilder.IConditionsStep Builder()
+	{
+		return new ConditionBuilder();
+	}
+
+	public ConditionAbility() { }
 
 	public ConditionAbility(ConditionModel[] conditions, int targets = 1, int? range = null, RangeType? rangeType = null,
 		Target? target = null,

--- a/Game/Scripts/Models/Abilities/ConditionAbility.cs
+++ b/Game/Scripts/Models/Abilities/ConditionAbility.cs
@@ -30,9 +30,17 @@ public class ConditionAbility : TargetedAbility<ConditionAbility.State, SingleTa
 			TBuilder WithConditions(params ConditionModel[] conditions);
 		}
 
-		public TBuilder WithConditions(params ConditionModel[] conditions)
+		public TBuilder WithAfterTargetConfirmedSubscription(
+			ScenarioEvent<ScenarioEvents.ConditionAfterTargetConfirmed.Parameters>.Subscription afterTargetConfirmedSubscription)
 		{
-			Obj.Conditions = conditions;
+			Obj.AfterTargetConfirmedSubscriptions.Add(afterTargetConfirmedSubscription);
+			return (TBuilder)this;
+		}
+
+		public TBuilder WithAfterTargetConfirmedSubscriptions(
+			List<ScenarioEvent<ScenarioEvents.ConditionAfterTargetConfirmed.Parameters>.Subscription> afterTargetConfirmedSubscriptions)
+		{
+			Obj.AfterTargetConfirmedSubscriptions = afterTargetConfirmedSubscriptions;
 			return (TBuilder)this;
 		}
 

--- a/Game/Scripts/Models/Abilities/ConditionAbility.cs
+++ b/Game/Scripts/Models/Abilities/ConditionAbility.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using Fractural.Tasks;
 
 /// <summary>
-/// A <see cref="TargetedAbility{T, TSingleTargetState}"/> that applies at least one condition to a figure.
+/// A <see cref="TargetedAbility{T, TSingleTargetState}"/> that allows a figure to apply conditions to other figures.
 /// </summary>
 public class ConditionAbility : TargetedAbility<ConditionAbility.State, SingleTargetState>
 {
@@ -12,7 +12,7 @@ public class ConditionAbility : TargetedAbility<ConditionAbility.State, SingleTa
 	}
 
 	public List<ScenarioEvent<ScenarioEvents.ConditionAfterTargetConfirmed.Parameters>.Subscription>
-		AfterTargetConfirmedSubscriptions { get; protected set; } = [];
+		AfterTargetConfirmedSubscriptions { get; private set; } = [];
 
 	/// <summary>
 	/// A builder extending <see cref="TargetedAbility{T, TSingleTargetState}.AbstractBuilder{TBuilder, TAbility}"/> with setter methods
@@ -53,7 +53,6 @@ public class ConditionAbility : TargetedAbility<ConditionAbility.State, SingleTa
 			Obj.Target = _target ?? ((Obj.Conditions.Length > 0 && Obj.Conditions[0].IsPositive) ? Target.SelfOrAllies : Target.Enemies);
 			return base.Build();
 		}
-
 	}
 
 	/// <summary>

--- a/Game/Scripts/Models/Abilities/GiveAbilityCardAbility.cs
+++ b/Game/Scripts/Models/Abilities/GiveAbilityCardAbility.cs
@@ -2,18 +2,97 @@
 using System.Collections.Generic;
 using Fractural.Tasks;
 
+/// <summary>
+/// A <see cref="TargetedAbility{T, TSingleTargetState}"/> that gives an ability card to another character.
+/// </summary>
 public class GiveAbilityCardAbility : TargetedAbility<GiveAbilityCardAbility.State, SingleTargetState>
 {
 	public class State : TargetedAbilityState<SingleTargetState>
 	{
 	}
 
-	private readonly Action<AbilityState, List<AbilityCard>> _getAbilityCards;
-	private readonly Func<AbilityState, AbilityCard, GDTask> _onCardGiven;
-	private readonly Func<AbilityCard, GDTask> _onCardDiscarded;
-	private readonly Func<AbilityCard, GDTask> _onCardLost;
+	protected Action<AbilityState, List<AbilityCard>> _getAbilityCards { get; set; }
+	protected Func<AbilityState, AbilityCard, GDTask> _onCardGiven { get; set; }
+	protected Func<AbilityCard, GDTask> _onCardDiscarded { get; set; }
+	protected Func<AbilityCard, GDTask> _onCardLost { get; set; }
 
-	private readonly bool _selectAutomatically;
+	protected bool _selectAutomatically { get; set; }
+
+	/// <summary>
+	/// A builder extending <see cref="TargetedAbility{T, TSingleTargetState}.AbstractBuilder{TBuilder, TAbility}"/> with setter methods
+	/// for values defined in GiveAbilityCardAbility. Enables inheritors of GiveAbilityCardAbility to further extend the builder.
+	/// </summary>
+	/// <typeparam name="TBuilder"></typeparam> Any builder extending this AbstractBuilder.
+	/// <typeparam name="TAbility"></typeparam> Any ability extending GiveAbilityCardAbility.
+	public new abstract class AbstractBuilder<TBuilder, TAbility> : TargetedAbility<State, SingleTargetState>.AbstractBuilder<TBuilder, TAbility>,
+		AbstractBuilder<TBuilder, TAbility>.IGetAbilityCardsStep
+		where TBuilder : AbstractBuilder<TBuilder, TAbility>
+		where TAbility : GiveAbilityCardAbility, new()
+	{
+		public interface IGetAbilityCardsStep
+		{
+			TBuilder WithGetAbilityCards(Action<AbilityState, List<AbilityCard>> getAbilityCards);
+		}
+
+		public TBuilder WithGetAbilityCards(Action<AbilityState, List<AbilityCard>> getAbilityCards)
+		{
+			Obj._getAbilityCards = getAbilityCards;
+			return (TBuilder)this;
+		}
+
+		public TBuilder WithOnCardGiven(Func<AbilityState, AbilityCard, GDTask> onCardGiven)
+		{
+			Obj._onCardGiven = onCardGiven;
+			return (TBuilder)this;
+		}
+
+		public TBuilder WithOnCardDiscarded(Func<AbilityCard, GDTask> onCardDiscarded)
+		{
+			Obj._onCardDiscarded = onCardDiscarded;
+			return (TBuilder)this;
+		}
+
+		public TBuilder WithOnCardLost(Func<AbilityCard, GDTask> onCardLost)
+		{
+			Obj._onCardLost = onCardLost;
+			return (TBuilder)this;
+		}
+
+		public TBuilder WithSelectAutomatically(bool selectAutomatically)
+		{
+			Obj._selectAutomatically = selectAutomatically;
+			return (TBuilder)this;
+		}
+
+		/// <summary>
+		/// Overriding so we can set default values.
+		/// </summary>
+		public override TAbility Build()
+		{
+			Obj.Target = _target ?? Target.Allies;
+			return base.Build();
+		}
+	}
+
+	/// <summary>
+	/// A concrete implementation of the AbstractBuilder. Required to actually use the builder,
+	/// as abstract builders cannot be instantiated.
+	/// </summary>
+	public class GiveAbilityCardBuilder : AbstractBuilder<GiveAbilityCardBuilder, GiveAbilityCardAbility>
+	{
+		internal GiveAbilityCardBuilder() { }
+	}
+
+	/// <summary>
+	/// A convenience method that returns an instance of GiveAbilityCardBuilder.
+	/// </summary>
+	/// <returns></returns>
+	public static GiveAbilityCardBuilder.IGetAbilityCardsStep Builder()
+	{
+		return new GiveAbilityCardBuilder();
+	}
+
+	public GiveAbilityCardAbility() { }
 
 	public GiveAbilityCardAbility(Action<AbilityState, List<AbilityCard>> getAbilityCards,
 		Func<AbilityState, AbilityCard, GDTask> onCardGiven = null,
@@ -53,7 +132,8 @@ public class GiveAbilityCardAbility : TargetedAbility<GiveAbilityCardAbility.Sta
 	}
 
 	public static async GDTask GiveAbilityCard(AbilityState abilityState, Figure target, Action<AbilityState, List<AbilityCard>> getAbilityCards,
-		Func<AbilityState, AbilityCard, GDTask> onCardGiven, Func<AbilityCard, GDTask> onCardDiscarded, Func<AbilityCard, GDTask> onCardLost, bool selectAutomatically = false)
+		Func<AbilityState, AbilityCard, GDTask> onCardGiven, Func<AbilityCard, GDTask> onCardDiscarded, Func<AbilityCard, GDTask> onCardLost,
+		bool selectAutomatically = false)
 	{
 		AbilityCard abilityCard;
 		if(selectAutomatically)

--- a/Game/Scripts/Models/Abilities/GiveAbilityCardAbility.cs
+++ b/Game/Scripts/Models/Abilities/GiveAbilityCardAbility.cs
@@ -11,12 +11,12 @@ public class GiveAbilityCardAbility : TargetedAbility<GiveAbilityCardAbility.Sta
 	{
 	}
 
-	protected Action<AbilityState, List<AbilityCard>> _getAbilityCards { get; set; }
-	protected Func<AbilityState, AbilityCard, GDTask> _onCardGiven { get; set; }
-	protected Func<AbilityCard, GDTask> _onCardDiscarded { get; set; }
-	protected Func<AbilityCard, GDTask> _onCardLost { get; set; }
+	private Action<AbilityState, List<AbilityCard>> _getAbilityCards;
+	private Func<AbilityState, AbilityCard, GDTask> _onCardGiven;
+	private Func<AbilityCard, GDTask> _onCardDiscarded;
+	private Func<AbilityCard, GDTask> _onCardLost;
 
-	protected bool _selectAutomatically { get; set; }
+	private bool _selectAutomatically;
 
 	/// <summary>
 	/// A builder extending <see cref="TargetedAbility{T, TSingleTargetState}.AbstractBuilder{TBuilder, TAbility}"/> with setter methods

--- a/Game/Scripts/Models/Abilities/GiveItemAbility.cs
+++ b/Game/Scripts/Models/Abilities/GiveItemAbility.cs
@@ -3,17 +3,91 @@ using System.Collections.Generic;
 using Fractural.Tasks;
 using Godot;
 
+/// <summary>
+/// A <see cref="TargetedAbility{T, TSingleTargetState}"/> that gives an item to another character.
+/// </summary>
 public class GiveItemAbility : TargetedAbility<GiveItemAbility.State, SingleTargetState>
 {
 	public class State : TargetedAbilityState<SingleTargetState>
 	{
 	}
 
-	private readonly Action<AbilityState, List<ItemModel>> _getItems;
-	private readonly Func<AbilityState, ItemModel, GDTask> _onItemGiven;
-	private readonly Func<ItemModel, GDTask> _onItemConsumed;
+	protected Action<AbilityState, List<ItemModel>> _getItems { get; set; }
+	protected Func<AbilityState, ItemModel, GDTask> _onItemGiven { get; set; }
+	protected Func<ItemModel, GDTask> _onItemConsumed { get; set; }
 
-	private readonly bool _selectAutomatically;
+	// TODO varadski 21.08.2025: also exists on GiveItemAbility; move to TargetAbility?
+	protected bool _selectAutomatically { get; set; }
+
+	/// <summary>
+	/// A builder extending <see cref="TargetedAbility{T, TSingleTargetState}.AbstractBuilder{TBuilder, TAbility}"/> with setter methods
+	/// for values defined in GiveItemAbility. Enables inheritors of GiveItemAbility to further extend the builder.
+	/// </summary>
+	/// <typeparam name="TBuilder"></typeparam> Any builder extending this AbstractBuilder.
+	/// <typeparam name="TAbility"></typeparam> Any ability extending GiveItemAbility.
+	public new abstract class AbstractBuilder<TBuilder, TAbility> : TargetedAbility<State, SingleTargetState>.AbstractBuilder<TBuilder, TAbility>,
+		AbstractBuilder<TBuilder, TAbility>.IGetItemsStep
+		where TBuilder : AbstractBuilder<TBuilder, TAbility>
+		where TAbility : GiveItemAbility, new()
+	{
+		public interface IGetItemsStep
+		{
+			TBuilder WithGetItems(Action<AbilityState, List<ItemModel>> getItems);
+		}
+
+		public TBuilder WithGetItems(Action<AbilityState, List<ItemModel>> getItems)
+		{
+			Obj._getItems = getItems;
+			return (TBuilder)this;
+		}
+
+		public TBuilder WithOnItemGiven(Func<AbilityState, ItemModel, GDTask> onItemGiven)
+		{
+			Obj._onItemGiven = onItemGiven;
+			return (TBuilder)this;
+		}
+
+		public TBuilder WithOnItemConsumed(Func<ItemModel, GDTask> onItemConsumed)
+		{
+			Obj._onItemConsumed = onItemConsumed;
+			return (TBuilder)this;
+		}
+
+		public TBuilder WithSelectAutomatically(bool selectAutomatically)
+		{
+			Obj._selectAutomatically = selectAutomatically;
+			return (TBuilder)this;
+		}
+
+		/// <summary>
+		/// Overriding so we can set default values.
+		/// </summary>
+		public override TAbility Build()
+		{
+			Obj.Target = _target ?? Target.Allies | Target.MustTargetCharacters;
+			return base.Build();
+		}
+	}
+
+	/// <summary>
+	/// A concrete implementation of the AbstractBuilder. Required to actually use the builder,
+	/// as abstract builders cannot be instantiated.
+	/// </summary>
+	public class GiveItemBuilder : AbstractBuilder<GiveItemBuilder, GiveItemAbility>
+	{
+		internal GiveItemBuilder() { }
+	}
+
+	/// <summary>
+	/// A convenience method that returns an instance of GiveItemBuilder.
+	/// </summary>
+	/// <returns></returns>
+	public static AbstractBuilder<GiveItemBuilder, GiveItemAbility>.IGetItemsStep Builder()
+	{
+		return new GiveItemBuilder();
+	}
+
+	public GiveItemAbility() { }
 
 	public GiveItemAbility(Action<AbilityState, List<ItemModel>> getItems,
 		Func<AbilityState, ItemModel, GDTask> onItemGiven = null,
@@ -28,8 +102,8 @@ public class GiveItemAbility : TargetedAbility<GiveItemAbility.State, SingleTarg
 		Func<State, GDTask> onAbilityStarted = null, Func<State, GDTask> onAbilityEnded = null, Func<State, GDTask> onAbilityEndedPerformed = null,
 		ConditionalAbilityCheckDelegate conditionalAbilityCheck = null,
 		Func<State, string> getTargetingHintText = null,
-		List<ScenarioEvents.AbilityStarted.Subscription> abilityStartedSubscriptions = null,
-		List<ScenarioEvents.AbilityEnded.Subscription> abilityEndedSubscriptions = null,
+		List<ScenarioEvent<ScenarioEvents.AbilityStarted.Parameters>.Subscription> abilityStartedSubscriptions = null,
+		List<ScenarioEvent<ScenarioEvents.AbilityEnded.Parameters>.Subscription> abilityEndedSubscriptions = null,
 		List<ScenarioEvent<ScenarioEvents.AbilityPerformed.Parameters>.Subscription> abilityPerformedSubscriptions = null)
 		: base(targets, range, rangeType, target,
 			requiresLineOfSight, mandatory, targetHex, aoePattern, push, pull, conditions,

--- a/Game/Scripts/Models/Abilities/GiveItemAbility.cs
+++ b/Game/Scripts/Models/Abilities/GiveItemAbility.cs
@@ -12,12 +12,10 @@ public class GiveItemAbility : TargetedAbility<GiveItemAbility.State, SingleTarg
 	{
 	}
 
-	protected Action<AbilityState, List<ItemModel>> _getItems { get; set; }
-	protected Func<AbilityState, ItemModel, GDTask> _onItemGiven { get; set; }
-	protected Func<ItemModel, GDTask> _onItemConsumed { get; set; }
-
-	// TODO varadski 21.08.2025: also exists on GiveItemAbility; move to TargetAbility?
-	protected bool _selectAutomatically { get; set; }
+	private Action<AbilityState, List<ItemModel>> _getItems;
+	private Func<AbilityState, ItemModel, GDTask> _onItemGiven;
+	private Func<ItemModel, GDTask> _onItemConsumed;
+	private bool _selectAutomatically;
 
 	/// <summary>
 	/// A builder extending <see cref="TargetedAbility{T, TSingleTargetState}.AbstractBuilder{TBuilder, TAbility}"/> with setter methods
@@ -82,7 +80,7 @@ public class GiveItemAbility : TargetedAbility<GiveItemAbility.State, SingleTarg
 	/// A convenience method that returns an instance of GiveItemBuilder.
 	/// </summary>
 	/// <returns></returns>
-	public static AbstractBuilder<GiveItemBuilder, GiveItemAbility>.IGetItemsStep Builder()
+	public static GiveItemBuilder.IGetItemsStep Builder()
 	{
 		return new GiveItemBuilder();
 	}

--- a/Game/Scripts/Models/Abilities/GrantAbility.cs
+++ b/Game/Scripts/Models/Abilities/GrantAbility.cs
@@ -2,15 +2,82 @@
 using System.Collections.Generic;
 using Fractural.Tasks;
 
+/// <summary>
+/// A <see cref="TargetedAbility{T, TSingleTargetState}"/> that gives the target figure an option to perform a given ability or abilities.
+/// </summary>
 public class GrantAbility : TargetedAbility<GrantAbility.State, SingleTargetState>
 {
 	public class State : TargetedAbilityState<SingleTargetState>
 	{
 	}
 
-	private readonly Func<Figure, List<Ability>> _getAbilities;
+	protected Func<Figure, List<Ability>> _getAbilities { get; set; }
 
-	public List<ScenarioEvents.DuringGrant.Subscription> DuringGrantSubscriptions { get; }
+	public List<ScenarioEvents.DuringGrant.Subscription> DuringGrantSubscriptions { get; protected set; } = [];
+
+	/// <summary>
+	/// A builder extending <see cref="TargetedAbility{T, TSingleTargetState}.AbstractBuilder{TBuilder, TAbility}"/> with setter methods
+	/// for values defined in GrantAbility. Enables inheritors of GrantAbility to further extend the builder.
+	/// </summary>
+	/// <typeparam name="TBuilder"></typeparam> Any builder extending this AbstractBuilder.
+	/// <typeparam name="TAbility"></typeparam> Any ability extending GrantAbility.
+	public new abstract class AbstractBuilder<TBuilder, TAbility> : TargetedAbility<State, SingleTargetState>.AbstractBuilder<TBuilder, TAbility>,
+		AbstractBuilder<TBuilder, TAbility>.IGetAbilitiesStep
+		where TBuilder : AbstractBuilder<TBuilder, TAbility>
+		where TAbility : GrantAbility, new()
+	{
+		public interface IGetAbilitiesStep
+		{
+			TBuilder WithGetAbilities(Func<Figure, List<Ability>> getAbilities);
+		}
+
+		public TBuilder WithGetAbilities(Func<Figure, List<Ability>> getAbilities)
+		{
+			Obj._getAbilities = getAbilities;
+			return (TBuilder)this;
+		}
+
+		public TBuilder WithDuringGrantSubscription(ScenarioEvents.DuringGrant.Subscription duringGrantSubscription)
+		{
+			Obj.DuringGrantSubscriptions.Add(duringGrantSubscription);
+			return (TBuilder)this;
+		}
+
+		public TBuilder WithDuringGrantSubscriptions(List<ScenarioEvents.DuringGrant.Subscription> duringGrantSubscriptions)
+		{
+			Obj.DuringGrantSubscriptions = duringGrantSubscriptions;
+			return (TBuilder)this;
+		}
+
+		/// <summary>
+		/// Overriding so we can set default values.
+		/// </summary>
+		public override TAbility Build()
+		{
+			Obj.Target = _target ?? Target.Allies;
+			return base.Build();
+		}
+	}
+
+	/// <summary>
+	/// A concrete implementation of the AbstractBuilder. Required to actually use the builder,
+	/// as abstract builders cannot be instantiated.
+	/// </summary>
+	public class GrantBuilder : AbstractBuilder<GrantBuilder, GrantAbility>
+	{
+		internal GrantBuilder() { }
+	}
+
+	/// <summary>
+	/// A convenience method that returns an instance of GrantBuilder.
+	/// </summary>
+	/// <returns></returns>
+	public static GrantBuilder.IGetAbilitiesStep Builder()
+	{
+		return new GrantBuilder();
+	}
+
+	public GrantAbility() { }
 
 	public GrantAbility(Func<Figure, List<Ability>> getAbilities, int targets = 1, int? range = null, RangeType? rangeType = null,
 		Target target = Target.Allies,
@@ -58,7 +125,8 @@ public class GrantAbility : TargetedAbility<GrantAbility.State, SingleTargetStat
 		await base.AfterTargetConfirmedBeforeConditionsApplied(abilityState, target);
 
 		// Perform the actual abilities
-		ActionState actionState = new ActionState(target, target is Character ? target : abilityState.Performer, _getAbilities(target), abilityState.ActionState);
+		ActionState actionState = new ActionState(target, target is Character ? target : abilityState.Performer, _getAbilities(target),
+			abilityState.ActionState);
 		await actionState.Perform();
 	}
 }

--- a/Game/Scripts/Models/Abilities/GrantAbility.cs
+++ b/Game/Scripts/Models/Abilities/GrantAbility.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using Fractural.Tasks;
 
 /// <summary>
-/// A <see cref="TargetedAbility{T, TSingleTargetState}"/> that gives the target figure an option to perform a given ability or abilities.
+/// A <see cref="TargetedAbility{T, TSingleTargetState}"/> that allows a figure to grant abilities to other figures.
 /// </summary>
 public class GrantAbility : TargetedAbility<GrantAbility.State, SingleTargetState>
 {
@@ -11,9 +11,9 @@ public class GrantAbility : TargetedAbility<GrantAbility.State, SingleTargetStat
 	{
 	}
 
-	protected Func<Figure, List<Ability>> _getAbilities { get; set; }
+	private Func<Figure, List<Ability>> _getAbilities;
 
-	public List<ScenarioEvents.DuringGrant.Subscription> DuringGrantSubscriptions { get; protected set; } = [];
+	public List<ScenarioEvents.DuringGrant.Subscription> DuringGrantSubscriptions { get; private set; } = [];
 
 	/// <summary>
 	/// A builder extending <see cref="TargetedAbility{T, TSingleTargetState}.AbstractBuilder{TBuilder, TAbility}"/> with setter methods

--- a/Game/Scripts/Models/Abilities/HealAbility.cs
+++ b/Game/Scripts/Models/Abilities/HealAbility.cs
@@ -3,6 +3,9 @@ using System.Collections.Generic;
 using Fractural.Tasks;
 using Godot;
 
+/// <summary>
+/// A <see cref="TargetedAbility{T, TSingleTargetState}"/> that restores hit points to the target figure.
+/// </summary>
 public class HealAbility : TargetedAbility<HealAbility.State, HealAbility.HealAbilitySingleTargetState>
 {
 	public class HealAbilitySingleTargetState : SingleTargetState
@@ -34,11 +37,106 @@ public class HealAbility : TargetedAbility<HealAbility.State, HealAbility.HealAb
 		}
 	}
 
-	public DynamicInt<State> HealValue { get; }
+	public DynamicInt<State> HealValue { get; protected set; }
 
-	public List<ScenarioEvent<ScenarioEvents.DuringHeal.Parameters>.Subscription> DuringHealSubscriptions { get; }
-	public List<ScenarioEvent<ScenarioEvents.HealAfterTargetConfirmed.Parameters>.Subscription> AfterTargetConfirmedSubscriptions { get; }
-	public List<ScenarioEvent<ScenarioEvents.AfterHealPerformed.Parameters>.Subscription> AfterHealPerformedSubscriptions { get; }
+	public List<ScenarioEvent<ScenarioEvents.DuringHeal.Parameters>.Subscription> DuringHealSubscriptions { get; protected set; } = [];
+	public List<ScenarioEvent<ScenarioEvents.HealAfterTargetConfirmed.Parameters>.Subscription>
+		AfterTargetConfirmedSubscriptions { get; protected set; } = [];
+	public List<ScenarioEvent<ScenarioEvents.AfterHealPerformed.Parameters>.Subscription>
+		AfterHealPerformedSubscriptions { get; protected set; } = [];
+
+	/// <summary>
+	/// A builder extending <see cref="TargetedAbility{T, TSingleTargetState}.AbstractBuilder{TBuilder, TAbility}"/> with setter methods
+	/// for values defined in HealAbility. Enables inheritors of HealAbility to further extend the builder.
+	/// </summary>
+	/// <typeparam name="TBuilder"></typeparam> Any builder extending this AbstractBuilder.
+	/// <typeparam name="TAbility"></typeparam> Any ability extending HealAbility.
+	public new abstract class AbstractBuilder<TBuilder, TAbility> :
+		TargetedAbility<State, HealAbilitySingleTargetState>.AbstractBuilder<TBuilder, TAbility>,
+		AbstractBuilder<TBuilder, TAbility>.IHealValueStep
+		where TBuilder : AbstractBuilder<TBuilder, TAbility>
+		where TAbility : HealAbility, new()
+	{
+		public interface IHealValueStep
+		{
+			TBuilder WithHealValue(DynamicInt<State> healValue);
+		}
+
+		public TBuilder WithHealValue(DynamicInt<State> healValue)
+		{
+			Obj.HealValue = healValue;
+			return (TBuilder)this;
+		}
+
+		public TBuilder WithDuringHealSubscription(ScenarioEvent<ScenarioEvents.DuringHeal.Parameters>.Subscription duringHealSubscription)
+		{
+			Obj.DuringHealSubscriptions.Add(duringHealSubscription);
+			return (TBuilder)this;
+		}
+
+		public TBuilder WithDuringHealSubscriptions(List<ScenarioEvent<ScenarioEvents.DuringHeal.Parameters>.Subscription> duringHealSubscriptions)
+		{
+			Obj.DuringHealSubscriptions = duringHealSubscriptions;
+			return (TBuilder)this;
+		}
+
+		public TBuilder WithAfterTargetConfirmedSubscription(
+			ScenarioEvent<ScenarioEvents.HealAfterTargetConfirmed.Parameters>.Subscription afterTargetConfirmedSubscription)
+		{
+			Obj.AfterTargetConfirmedSubscriptions.Add(afterTargetConfirmedSubscription);
+			return (TBuilder)this;
+		}
+
+		public TBuilder WithAfterTargetConfirmedSubscriptions(
+			List<ScenarioEvent<ScenarioEvents.HealAfterTargetConfirmed.Parameters>.Subscription> afterTargetConfirmedSubscriptions)
+		{
+			Obj.AfterTargetConfirmedSubscriptions = afterTargetConfirmedSubscriptions;
+			return (TBuilder)this;
+		}
+
+		public TBuilder WithAfterHealPerformedSubscription(
+			ScenarioEvent<ScenarioEvents.AfterHealPerformed.Parameters>.Subscription afterHealPerformedSubscriptions)
+		{
+			Obj.AfterHealPerformedSubscriptions.Add(afterHealPerformedSubscriptions);
+			return (TBuilder)this;
+		}
+
+		public TBuilder WithAfterHealPerformedSubscriptions(
+			List<ScenarioEvent<ScenarioEvents.AfterHealPerformed.Parameters>.Subscription> afterHealPerformedSubscriptionss)
+		{
+			Obj.AfterHealPerformedSubscriptions = afterHealPerformedSubscriptionss;
+			return (TBuilder)this;
+		}
+
+		/// <summary>
+		/// Overriding so we can set default values.
+		/// </summary>
+		public override TAbility Build()
+		{
+			Obj.Target = _target ?? Target.SelfOrAllies;
+			return base.Build();
+		}
+	}
+
+	/// <summary>
+	/// A concrete implementation of the AbstractBuilder. Required to actually use the builder,
+	/// as abstract builders cannot be instantiated.
+	/// </summary>
+	public class HealBuilder : AbstractBuilder<HealBuilder, HealAbility>
+	{
+		internal HealBuilder() { }
+	}
+
+	/// <summary>
+	/// A convenience method that returns an instance of HealBuilder.
+	/// </summary>
+	/// <returns></returns>
+	public static AbstractBuilder<HealBuilder, HealAbility>.IHealValueStep Builder()
+	{
+		return new HealBuilder();
+	}
+
+	public HealAbility() { }
 
 	public HealAbility(DynamicInt<State> value, int targets = 1, int? range = null, RangeType? rangeType = null,
 		Target target = Target.SelfOrAllies,

--- a/Game/Scripts/Models/Abilities/HealAbility.cs
+++ b/Game/Scripts/Models/Abilities/HealAbility.cs
@@ -4,7 +4,7 @@ using Fractural.Tasks;
 using Godot;
 
 /// <summary>
-/// A <see cref="TargetedAbility{T, TSingleTargetState}"/> that restores hit points to the target figure.
+/// A <see cref="TargetedAbility{T, TSingleTargetState}"/> that allows a figure to restore hit points to other figures.
 /// </summary>
 public class HealAbility : TargetedAbility<HealAbility.State, HealAbility.HealAbilitySingleTargetState>
 {
@@ -37,13 +37,15 @@ public class HealAbility : TargetedAbility<HealAbility.State, HealAbility.HealAb
 		}
 	}
 
-	public DynamicInt<State> HealValue { get; protected set; }
+	public DynamicInt<State> HealValue { get; private set; }
 
-	public List<ScenarioEvent<ScenarioEvents.DuringHeal.Parameters>.Subscription> DuringHealSubscriptions { get; protected set; } = [];
+	public List<ScenarioEvent<ScenarioEvents.DuringHeal.Parameters>.Subscription> DuringHealSubscriptions { get; private set; } = [];
+
 	public List<ScenarioEvent<ScenarioEvents.HealAfterTargetConfirmed.Parameters>.Subscription>
-		AfterTargetConfirmedSubscriptions { get; protected set; } = [];
+		AfterTargetConfirmedSubscriptions { get; private set; } = [];
+
 	public List<ScenarioEvent<ScenarioEvents.AfterHealPerformed.Parameters>.Subscription>
-		AfterHealPerformedSubscriptions { get; protected set; } = [];
+		AfterHealPerformedSubscriptions { get; private set; } = [];
 
 	/// <summary>
 	/// A builder extending <see cref="TargetedAbility{T, TSingleTargetState}.AbstractBuilder{TBuilder, TAbility}"/> with setter methods
@@ -131,7 +133,7 @@ public class HealAbility : TargetedAbility<HealAbility.State, HealAbility.HealAb
 	/// A convenience method that returns an instance of HealBuilder.
 	/// </summary>
 	/// <returns></returns>
-	public static AbstractBuilder<HealBuilder, HealAbility>.IHealValueStep Builder()
+	public static HealBuilder.IHealValueStep Builder()
 	{
 		return new HealBuilder();
 	}

--- a/Game/Scripts/Models/Abilities/LootAbility.cs
+++ b/Game/Scripts/Models/Abilities/LootAbility.cs
@@ -3,6 +3,9 @@ using System.Collections.Generic;
 using Fractural.Tasks;
 using Godot;
 
+/// <summary>
+/// An <see cref="Ability{T}"/> that picks up coins from hexes within range.
+/// </summary>
 public class LootAbility : Ability<LootAbility.State>
 {
 	public class State : AbilityState
@@ -12,16 +15,70 @@ public class LootAbility : Ability<LootAbility.State>
 		public int TotalLootedCount { get; set; }
 	}
 
-	private readonly Func<State, Figure> _customGetLootObtainer;
-	public int Range { get; }
+	private Func<State, Figure> _customGetLootObtainer { get; set; }
+	// TODO varadski 20.08.2025: Common ability between loot and TargetedAbility; move it to Ability.cs?
+	public int Range { get; protected set; }
+
+	/// <summary>
+	/// A builder extending <see cref="Ability{T}.AbstractBuilder{TBuilder, TAbility}"/> with setter methods
+	/// for values defined in LootAbility. Enables inheritors of LootAbility to further extend the builder.
+	/// </summary>
+	/// <typeparam name="TBuilder"></typeparam> Any builder extending this AbstractBuilder.
+	/// <typeparam name="TAbility"></typeparam> Any ability extending LootAbility.
+	public new abstract class AbstractBuilder<TBuilder, TAbility> : Ability<State>.AbstractBuilder<TBuilder, TAbility>,
+		AbstractBuilder<TBuilder, TAbility>.IRangeStep
+		where TBuilder : AbstractBuilder<TBuilder, TAbility>
+		where TAbility : LootAbility, new()
+	{
+
+		public interface IRangeStep
+		{
+			TBuilder WithRange(int range);
+		}
+
+		public TBuilder WithCustomGetLootObtainer(Func<State, Figure> customGetLootObtainer)
+		{
+			Obj._customGetLootObtainer = customGetLootObtainer;
+			return (TBuilder)this;
+		}
+
+		public TBuilder WithRange(int range)
+		{
+			Obj.Range = range;
+			return (TBuilder)this;
+		}
+	}
+
+	/// <summary>
+	/// A concrete implementation of the AbstractBuilder. Required to actually use the builder,
+	/// as abstract builders cannot be instantiated.
+	/// </summary>
+	public class LootBuilder : AbstractBuilder<LootBuilder, LootAbility>
+	{
+		internal LootBuilder() { }
+	}
+
+	/// <summary>
+	/// A convenience method that returns an instance of LootBuilder.
+	/// </summary>
+	/// <returns></returns>
+	public static AbstractBuilder<LootBuilder, LootAbility>.IRangeStep Builder()
+	{
+		return new LootBuilder();
+	}
+
+
+	public LootAbility() { }
 
 	public LootAbility(int range, Func<State, Figure> customGetLootObtainer = null,
-		Func<State, GDTask> onAbilityStarted = null, Func<State, GDTask> onAbilityEnded = null, Func<State, GDTask> onAbilityEndedPerformed = null,
+		Func<State, GDTask> onAbilityStarted = null, Func<State, GDTask> onAbilityEnded = null,
+		Func<State, GDTask> onAbilityEndedPerformed = null,
 		ConditionalAbilityCheckDelegate conditionalAbilityCheck = null,
-		List<ScenarioEvents.AbilityStarted.Subscription> abilityStartedSubscriptions = null,
-		List<ScenarioEvents.AbilityEnded.Subscription> abilityEndedSubscriptions = null,
-		List<ScenarioEvents.AbilityPerformed.Subscription> abilityPerformedSubscriptions = null)
-		: base(onAbilityStarted, onAbilityEnded, onAbilityEndedPerformed, conditionalAbilityCheck, abilityStartedSubscriptions, abilityEndedSubscriptions, abilityPerformedSubscriptions)
+		List<ScenarioEvent<ScenarioEvents.AbilityStarted.Parameters>.Subscription> abilityStartedSubscriptions = null,
+		List<ScenarioEvent<ScenarioEvents.AbilityEnded.Parameters>.Subscription> abilityEndedSubscriptions = null,
+		List<ScenarioEvent<ScenarioEvents.AbilityPerformed.Parameters>.Subscription> abilityPerformedSubscriptions = null)
+		: base(onAbilityStarted, onAbilityEnded, onAbilityEndedPerformed, conditionalAbilityCheck,
+			abilityStartedSubscriptions, abilityEndedSubscriptions, abilityPerformedSubscriptions)
 	{
 		_customGetLootObtainer = customGetLootObtainer;
 		Range = range;

--- a/Game/Scripts/Models/Abilities/LootAbility.cs
+++ b/Game/Scripts/Models/Abilities/LootAbility.cs
@@ -4,7 +4,7 @@ using Fractural.Tasks;
 using Godot;
 
 /// <summary>
-/// An <see cref="Ability{T}"/> that picks up coins from hexes within range.
+/// An <see cref="Ability{T}"/> that allows a figure to pick up loot tokens (coins and treasure chests) within range.
 /// </summary>
 public class LootAbility : Ability<LootAbility.State>
 {
@@ -16,7 +16,6 @@ public class LootAbility : Ability<LootAbility.State>
 	}
 
 	private Func<State, Figure> _customGetLootObtainer { get; set; }
-	// TODO varadski 20.08.2025: Common ability between loot and TargetedAbility; move it to Ability.cs?
 	public int Range { get; protected set; }
 
 	/// <summary>
@@ -30,7 +29,6 @@ public class LootAbility : Ability<LootAbility.State>
 		where TBuilder : AbstractBuilder<TBuilder, TAbility>
 		where TAbility : LootAbility, new()
 	{
-
 		public interface IRangeStep
 		{
 			TBuilder WithRange(int range);
@@ -62,7 +60,7 @@ public class LootAbility : Ability<LootAbility.State>
 	/// A convenience method that returns an instance of LootBuilder.
 	/// </summary>
 	/// <returns></returns>
-	public static AbstractBuilder<LootBuilder, LootAbility>.IRangeStep Builder()
+	public static LootBuilder.IRangeStep Builder()
 	{
 		return new LootBuilder();
 	}

--- a/Game/Scripts/Models/Abilities/MoveAbility.cs
+++ b/Game/Scripts/Models/Abilities/MoveAbility.cs
@@ -5,6 +5,9 @@ using Godot;
 using GTweens.Easings;
 using GTweensGodot.Extensions;
 
+/// <summary>
+/// An <see cref="Ability{T}"/> that allows figures to move.
+/// </summary>
 public class MoveAbility : Ability<MoveAbility.State>
 {
 	public class State : AbilityState
@@ -34,20 +37,84 @@ public class MoveAbility : Ability<MoveAbility.State>
 		}
 	}
 
-	public int Distance { get; }
-	public MoveType MoveType { get; }
-	public List<ScenarioEvent<ScenarioEvents.DuringMovement.Parameters>.Subscription> DuringMovementSubscriptions { get; }
+	public int Distance { get; protected set; }
+	public MoveType MoveType { get; protected set; }
+	public List<ScenarioEvent<ScenarioEvents.DuringMovement.Parameters>.Subscription> DuringMovementSubscriptions { get; protected set; } = [];
 	//public List<ScenarioEvent<ScenarioEvents.FigureEnteredHex.Parameters>.Subscription> FigureEnteredHexSubscriptions { get; }
 
+	/// <summary>
+	/// A builder extending <see cref="Ability{T}.AbstractBuilder{TBuilder, TAbility}"/> with setter methods
+	/// for values defined in MoveAbility. Enables inheritors of MoveAbility to further extend the builder.
+	/// </summary>
+	/// <typeparam name="TBuilder"></typeparam> Any builder extending this AbstractBuilder.
+	/// <typeparam name="TAbility"></typeparam> Any ability extending MoveAbility.
+	public new abstract class AbstractBuilder<TBuilder, TAbility> : Ability<State>.AbstractBuilder<TBuilder, TAbility>,
+		AbstractBuilder<TBuilder, TAbility>.IDistanceStep
+		where TBuilder : AbstractBuilder<TBuilder, TAbility>
+		where TAbility : MoveAbility, new()
+	{
+		public interface IDistanceStep
+		{
+			TBuilder WithDistance(int distance);
+		}
+
+		public TBuilder WithDistance(int distance)
+		{
+			Obj.Distance = distance;
+			return (TBuilder)this;
+		}
+
+		public TBuilder WithMoveType(MoveType moveType)
+		{
+			Obj.MoveType = moveType;
+			return (TBuilder)this;
+		}
+
+		public TBuilder WithDuringMovementSubscription(ScenarioEvent<ScenarioEvents.DuringMovement.Parameters>.Subscription movementSubscription)
+		{
+			Obj.DuringMovementSubscriptions.Add(movementSubscription);
+			return (TBuilder)this;
+		}
+
+		public TBuilder WithDuringMovementSubscriptions(
+			List<ScenarioEvent<ScenarioEvents.DuringMovement.Parameters>.Subscription> movementSubscriptions)
+		{
+			Obj.DuringMovementSubscriptions = movementSubscriptions;
+			return (TBuilder)this;
+		}
+	}
+
+	/// <summary>
+	/// A concrete implementation of the AbstractBuilder. Required to actually use the builder,
+	/// as abstract builders cannot be instantiated.
+	/// </summary>
+	public class MoveBuilder : AbstractBuilder<MoveBuilder, MoveAbility>
+	{
+		internal MoveBuilder() { }
+	}
+
+	/// <summary>
+	/// A convenience method that returns an instance of MoveBuilder.
+	/// </summary>
+	/// <returns></returns>
+	public static MoveBuilder.IDistanceStep Builder()
+	{
+		return new MoveBuilder();
+	}
+
+	public MoveAbility() { }
+
 	public MoveAbility(int distance, MoveType moveType = MoveType.Regular,
-		Func<State, GDTask> onAbilityStarted = null, Func<State, GDTask> onAbilityEnded = null, Func<State, GDTask> onAbilityEndedPerformed = null,
+		Func<State, GDTask> onAbilityStarted = null, Func<State, GDTask> onAbilityEnded = null,
+		Func<State, GDTask> onAbilityEndedPerformed = null,
 		ConditionalAbilityCheckDelegate conditionalAbilityCheck = null,
-		List<ScenarioEvents.DuringMovement.Subscription> duringMovementSubscriptions = null,
+		List<ScenarioEvent<ScenarioEvents.DuringMovement.Parameters>.Subscription> duringMovementSubscriptions = null,
 		//List<ScenarioEvents.FigureEnteredHex.Subscription> figureEnteredHexSubscriptions = null,
-		List<ScenarioEvents.AbilityStarted.Subscription> abilityStartedSubscriptions = null,
-		List<ScenarioEvents.AbilityEnded.Subscription> abilityEndedSubscriptions = null,
-		List<ScenarioEvents.AbilityPerformed.Subscription> abilityPerformedSubscriptions = null)
-		: base(onAbilityStarted, onAbilityEnded, onAbilityEndedPerformed, conditionalAbilityCheck, abilityStartedSubscriptions, abilityEndedSubscriptions, abilityPerformedSubscriptions)
+		List<ScenarioEvent<ScenarioEvents.AbilityStarted.Parameters>.Subscription> abilityStartedSubscriptions = null,
+		List<ScenarioEvent<ScenarioEvents.AbilityEnded.Parameters>.Subscription> abilityEndedSubscriptions = null,
+		List<ScenarioEvent<ScenarioEvents.AbilityPerformed.Parameters>.Subscription> abilityPerformedSubscriptions = null)
+		: base(onAbilityStarted, onAbilityEnded, onAbilityEndedPerformed, conditionalAbilityCheck,
+			abilityStartedSubscriptions, abilityEndedSubscriptions, abilityPerformedSubscriptions)
 	{
 		Distance = distance;
 		MoveType = moveType;
@@ -88,7 +155,10 @@ public class MoveAbility : Ability<MoveAbility.State>
 
 			bool playedLandSound = false;
 
-			for(int i = 0; i < path.Count && !performer.IsDestroyed && !performer.HasCondition(Conditions.Immobilize) && !performer.HasCondition(Conditions.Stun); i++)
+			for(int i = 0;
+			    i < path.Count && !performer.IsDestroyed && !performer.HasCondition(Conditions.Immobilize) &&
+			    !performer.HasCondition(Conditions.Stun);
+			    i++)
 			{
 				Vector2I coords = path[i];
 				Hex hex = GameController.Instance.Map.GetHex(coords);
@@ -100,20 +170,24 @@ public class MoveAbility : Ability<MoveAbility.State>
 
 				if(abilityState.MoveType == MoveType.Flying)
 				{
-					AppController.Instance.AudioController.PlayFastForwardable(SFX.MoveFlying, minPitch: 2.5f, maxPitch: 3.4f, delay: 0.1f);
+					AppController.Instance.AudioController.PlayFastForwardable(SFX.MoveFlying, minPitch: 2.5f,
+						maxPitch: 3.4f, delay: 0.1f);
 				}
 
 				if(abilityState.MoveType == MoveType.Jump && i == path.Count - 1)
 				{
 					playedLandSound = true;
-					AppController.Instance.AudioController.PlayFastForwardable(SFX.GetLand(performer.Hex), delay: 0.25f);
+					AppController.Instance.AudioController.PlayFastForwardable(SFX.GetLand(performer.Hex),
+						delay: 0.25f);
 				}
 
 				abilityState.Hexes.Add(hex);
 
-				await performer.TweenGlobalPosition(hex.GlobalPosition, 0.3f).SetEasing(Easing.OutSine).PlayFastForwardableAsync();
+				await performer.TweenGlobalPosition(hex.GlobalPosition, 0.3f).SetEasing(Easing.OutSine)
+					.PlayFastForwardableAsync();
 				await GDTask.DelayFastForwardable(0.03f);
-				bool triggerHexEffects = abilityState.MoveType == MoveType.Regular || (abilityState.MoveType == MoveType.Jump && i == path.Count - 1);
+				bool triggerHexEffects = abilityState.MoveType == MoveType.Regular ||
+				                         (abilityState.MoveType == MoveType.Jump && i == path.Count - 1);
 				await AbilityCmd.EnterHex(abilityState, performer, abilityState.Authority, hex, triggerHexEffects);
 			}
 
@@ -128,7 +202,8 @@ public class MoveAbility : Ability<MoveAbility.State>
 		if(abilityState.Authority is Character)
 		{
 			// Character moving
-			ScenarioEvents.DuringMovement.Parameters duringMovementAbilityStateParameters = new ScenarioEvents.DuringMovement.Parameters(abilityState);
+			ScenarioEvents.DuringMovement.Parameters duringMovementAbilityStateParameters =
+				new ScenarioEvents.DuringMovement.Parameters(abilityState);
 
 			performer.SetZIndex(100);
 
@@ -143,7 +218,8 @@ public class MoveAbility : Ability<MoveAbility.State>
 					ScenarioEvents.DuringMovementEvent.CreateEffectCollection(duringMovementAbilityStateParameters);
 
 				MovePrompt.Answer moveAnswer = await PromptManager.Prompt(
-					new MovePrompt(abilityState, performer, effectCollection, () => "Select a path"), abilityState.Authority);
+					new MovePrompt(abilityState, performer, effectCollection, () => "Select a path"),
+					abilityState.Authority);
 
 				if(moveAnswer.Skipped)
 				{
@@ -163,7 +239,8 @@ public class MoveAbility : Ability<MoveAbility.State>
 		{
 			// Monster moving
 			MonsterMovePrompt.Answer monsterMoveAnswer = await PromptManager.Prompt(
-				new MonsterMovePrompt(abilityState, performer, abilityState.ActionState.GetAIMoveParameters(), await abilityState.ActionState.GetFocus(),
+				new MonsterMovePrompt(abilityState, performer, abilityState.ActionState.GetAIMoveParameters(),
+					await abilityState.ActionState.GetFocus(),
 					null, () => "Select a path"), abilityState.Authority);
 
 			performer.SetZIndex(100);

--- a/Game/Scripts/Models/Abilities/MoveAbility.cs
+++ b/Game/Scripts/Models/Abilities/MoveAbility.cs
@@ -37,9 +37,9 @@ public class MoveAbility : Ability<MoveAbility.State>
 		}
 	}
 
-	public int Distance { get; protected set; }
-	public MoveType MoveType { get; protected set; }
-	public List<ScenarioEvent<ScenarioEvents.DuringMovement.Parameters>.Subscription> DuringMovementSubscriptions { get; protected set; } = [];
+	public int Distance { get; private set; }
+	public MoveType MoveType { get; private set; }
+	public List<ScenarioEvent<ScenarioEvents.DuringMovement.Parameters>.Subscription> DuringMovementSubscriptions { get; private set; } = [];
 	//public List<ScenarioEvent<ScenarioEvents.FigureEnteredHex.Parameters>.Subscription> FigureEnteredHexSubscriptions { get; }
 
 	/// <summary>
@@ -186,8 +186,7 @@ public class MoveAbility : Ability<MoveAbility.State>
 				await performer.TweenGlobalPosition(hex.GlobalPosition, 0.3f).SetEasing(Easing.OutSine)
 					.PlayFastForwardableAsync();
 				await GDTask.DelayFastForwardable(0.03f);
-				bool triggerHexEffects = abilityState.MoveType == MoveType.Regular ||
-				                         (abilityState.MoveType == MoveType.Jump && i == path.Count - 1);
+				bool triggerHexEffects = abilityState.MoveType == MoveType.Regular || (abilityState.MoveType == MoveType.Jump && i == path.Count - 1);
 				await AbilityCmd.EnterHex(abilityState, performer, abilityState.Authority, hex, triggerHexEffects);
 			}
 
@@ -217,9 +216,9 @@ public class MoveAbility : Ability<MoveAbility.State>
 				EffectCollection effectCollection =
 					ScenarioEvents.DuringMovementEvent.CreateEffectCollection(duringMovementAbilityStateParameters);
 
-				MovePrompt.Answer moveAnswer = await PromptManager.Prompt(
-					new MovePrompt(abilityState, performer, effectCollection, () => "Select a path"),
-					abilityState.Authority);
+				MovePrompt.Answer moveAnswer =
+					await PromptManager.Prompt(new MovePrompt(abilityState, performer, effectCollection, () => "Select a path"),
+						abilityState.Authority);
 
 				if(moveAnswer.Skipped)
 				{

--- a/Game/Scripts/Models/Abilities/OtherAbility.cs
+++ b/Game/Scripts/Models/Abilities/OtherAbility.cs
@@ -19,10 +19,17 @@ public class OtherAbility : Ability<OtherAbility.State>
 	/// </summary>
 	/// <typeparam name="TBuilder"></typeparam> Any builder extending this AbstractBuilder.
 	/// <typeparam name="TAbility"></typeparam> Any ability extending OtherAbility.
-	public new abstract class AbstractBuilder<TBuilder, TAbility> : Ability<State>.AbstractBuilder<TBuilder, TAbility>
+	public new abstract class AbstractBuilder<TBuilder, TAbility> : Ability<State>.AbstractBuilder<TBuilder, TAbility>,
+		AbstractBuilder<TBuilder, TAbility>.IPerformAbilityStep
 		where TBuilder : AbstractBuilder<TBuilder, TAbility>
 		where TAbility : OtherAbility, new()
 	{
+
+		public interface IPerformAbilityStep
+		{
+			TBuilder WithPerformAbility(Func<State, GDTask> performAbility);
+		}
+
 		public TBuilder WithPerformAbility(Func<State, GDTask> performAbility)
 		{
 			Obj._performAbility = performAbility;
@@ -43,7 +50,7 @@ public class OtherAbility : Ability<OtherAbility.State>
 	/// A convenience method that returns an instance of OtherAbilityBuilder.
 	/// </summary>
 	/// <returns></returns>
-	public static OtherBuilder Builder()
+	public static OtherBuilder.IPerformAbilityStep Builder()
 	{
 		return new OtherBuilder();
 	}

--- a/Game/Scripts/Models/Abilities/OtherAbility.cs
+++ b/Game/Scripts/Models/Abilities/OtherAbility.cs
@@ -2,21 +2,62 @@
 using System.Collections.Generic;
 using Fractural.Tasks;
 
+/// <summary>
+/// An <see cref="Ability{T}"/> that does not neatly fit any other dedicated ability implementation.
+/// </summary>
 public class OtherAbility : Ability<OtherAbility.State>
 {
 	public class State : AbilityState
 	{
 	}
 
-	private readonly Func<State, GDTask> _performAbility;
+	private Func<State, GDTask> _performAbility { get; set; }
+
+	/// <summary>
+	/// A builder extending <see cref="Ability{T}.AbstractBuilder{TBuilder, TAbility}"/> with setter methods
+	/// for values defined in OtherAbility. Enables inheritors of OtherAbility to further extend the builder.
+	/// </summary>
+	/// <typeparam name="TBuilder"></typeparam> Any builder extending this AbstractBuilder.
+	/// <typeparam name="TAbility"></typeparam> Any ability extending OtherAbility.
+	public new abstract class AbstractBuilder<TBuilder, TAbility> : Ability<State>.AbstractBuilder<TBuilder, TAbility>
+		where TBuilder : AbstractBuilder<TBuilder, TAbility>
+		where TAbility : OtherAbility, new()
+	{
+		public TBuilder WithPerformAbility(Func<State, GDTask> performAbility)
+		{
+			Obj._performAbility = performAbility;
+			return (TBuilder)this;
+		}
+	}
+
+	/// <summary>
+	/// A concrete implementation of the AbstractBuilder. Required to actually use the builder,
+	/// as abstract builders cannot be instantiated.
+	/// </summary>
+	public class OtherBuilder : AbstractBuilder<OtherBuilder, OtherAbility>
+	{
+		internal OtherBuilder() { }
+	}
+
+	/// <summary>
+	/// A convenience method that returns an instance of OtherAbilityBuilder.
+	/// </summary>
+	/// <returns></returns>
+	public static OtherBuilder Builder()
+	{
+		return new OtherBuilder();
+	}
+
+	public OtherAbility() { }
 
 	public OtherAbility(Func<State, GDTask> performAbility,
 		Func<State, GDTask> onAbilityStarted = null, Func<State, GDTask> onAbilityEnded = null, Func<State, GDTask> onAbilityEndedPerformed = null,
 		ConditionalAbilityCheckDelegate conditionalAbilityCheck = null,
-		List<ScenarioEvents.AbilityStarted.Subscription> abilityStartedSubscriptions = null,
-		List<ScenarioEvents.AbilityEnded.Subscription> abilityEndedSubscriptions = null,
-		List<ScenarioEvents.AbilityPerformed.Subscription> abilityPerformedSubscriptions = null)
-		: base(onAbilityStarted, onAbilityEnded, onAbilityEndedPerformed, conditionalAbilityCheck, abilityStartedSubscriptions, abilityEndedSubscriptions, abilityPerformedSubscriptions)
+		List<ScenarioEvent<ScenarioEvents.AbilityStarted.Parameters>.Subscription> abilityStartedSubscriptions = null,
+		List<ScenarioEvent<ScenarioEvents.AbilityEnded.Parameters>.Subscription> abilityEndedSubscriptions = null,
+		List<ScenarioEvent<ScenarioEvents.AbilityPerformed.Parameters>.Subscription> abilityPerformedSubscriptions = null)
+		: base(onAbilityStarted, onAbilityEnded, onAbilityEndedPerformed, conditionalAbilityCheck, abilityStartedSubscriptions,
+			abilityEndedSubscriptions, abilityPerformedSubscriptions)
 	{
 		_performAbility = performAbility;
 	}

--- a/Game/Scripts/Models/Abilities/OtherAbility.cs
+++ b/Game/Scripts/Models/Abilities/OtherAbility.cs
@@ -24,7 +24,6 @@ public class OtherAbility : Ability<OtherAbility.State>
 		where TBuilder : AbstractBuilder<TBuilder, TAbility>
 		where TAbility : OtherAbility, new()
 	{
-
 		public interface IPerformAbilityStep
 		{
 			TBuilder WithPerformAbility(Func<State, GDTask> performAbility);

--- a/Game/Scripts/Models/Abilities/OtherActiveAbility.cs
+++ b/Game/Scripts/Models/Abilities/OtherActiveAbility.cs
@@ -2,23 +2,83 @@
 using System.Collections.Generic;
 using Fractural.Tasks;
 
+/// <summary>
+/// An <see cref="ActiveAbility{T}"/> that does not neatly fit any other dedicated ability implementation.
+/// </summary>
 public class OtherActiveAbility : ActiveAbility<OtherActiveAbility.State>
 {
 	public class State : ActiveAbilityState
 	{
 	}
 
-	public Func<State, GDTask> OnActivate { get; }
-	public Func<State, GDTask> OnDeactivate { get; }
+	public Func<State, GDTask> OnActivate { get; protected set; }
+	public Func<State, GDTask> OnDeactivate { get; protected set; }
+
+	/// <summary>
+	/// A builder extending <see cref="ActiveAbility{T}.AbstractBuilder{TBuilder, TAbility}"/> with setter methods
+	/// for values defined in OtherActiveAbility. Enables inheritors of OtherActiveAbility to further extend the builder.
+	/// </summary>
+	/// <typeparam name="TBuilder"></typeparam> Any builder extending this AbstractBuilder.
+	/// <typeparam name="TAbility"></typeparam> Any ability extending OtherActiveAbility.
+	public new class AbstractBuilder<TBuilder, TAbility> : ActiveAbility<State>.AbstractBuilder<TBuilder, TAbility>,
+		AbstractBuilder<TBuilder, TAbility>.IOnActivateStep,
+		AbstractBuilder<TBuilder, TAbility>.IOnDeactivateStep
+		where TBuilder : AbstractBuilder<TBuilder, TAbility>
+		where TAbility : OtherActiveAbility, new()
+	{
+
+		public interface IOnActivateStep
+		{
+			IOnDeactivateStep WithOnActivate(Func<State, GDTask> onActivate);
+		}
+
+		public interface IOnDeactivateStep
+		{
+			TBuilder WithOnDeactivate(Func<State, GDTask> onDeactivate);
+		}
+
+		public IOnDeactivateStep WithOnActivate(Func<State, GDTask> onActivate)
+		{
+			Obj.OnActivate = onActivate;
+			return (TBuilder)this;
+		}
+
+		public TBuilder WithOnDeactivate(Func<State, GDTask> onDeactivate)
+		{
+			Obj.OnDeactivate = onDeactivate;
+			return (TBuilder)this;
+		}
+	}
+
+	/// <summary>
+	/// A concrete implementation of the AbstractBuilder. Required to actually use the builder,
+	/// as abstract builders cannot be instantiated.
+	/// </summary>
+	public class OtherActiveBuilder : AbstractBuilder<OtherActiveBuilder, OtherActiveAbility>
+	{
+		internal OtherActiveBuilder() { }
+	}
+
+	/// <summary>
+	/// A convenience method that returns an instance of OtherActiveBuilder.
+	/// </summary>
+	/// <returns></returns>
+	public static AbstractBuilder<OtherActiveBuilder, OtherActiveAbility>.IOnActivateStep Builder()
+	{
+		return new OtherActiveBuilder();
+	}
+
+	public OtherActiveAbility() { }
 
 	public OtherActiveAbility(Func<State, GDTask> onActivate, Func<State, GDTask> onDeactivate,
 		Func<State, GDTask> onAbilityStarted = null, Func<State, GDTask> onAbilityEnded = null, Func<State, GDTask> onAbilityEndedPerformed = null,
 		ConditionalAbilityCheckDelegate conditionalAbilityCheck = null,
 		Func<State, string> getHintText = null,
-		List<ScenarioEvents.AbilityStarted.Subscription> abilityStartedSubscriptions = null,
-		List<ScenarioEvents.AbilityEnded.Subscription> abilityEndedSubscriptions = null,
+		List<ScenarioEvent<ScenarioEvents.AbilityStarted.Parameters>.Subscription> abilityStartedSubscriptions = null,
+		List<ScenarioEvent<ScenarioEvents.AbilityEnded.Parameters>.Subscription> abilityEndedSubscriptions = null,
 		List<ScenarioEvent<ScenarioEvents.AbilityPerformed.Parameters>.Subscription> abilityPerformedSubscriptions = null)
-		: base(onAbilityStarted, onAbilityEnded, onAbilityEndedPerformed, conditionalAbilityCheck, getHintText, abilityStartedSubscriptions, abilityEndedSubscriptions, abilityPerformedSubscriptions)
+		: base(onAbilityStarted, onAbilityEnded, onAbilityEndedPerformed, conditionalAbilityCheck, getHintText, abilityStartedSubscriptions,
+			abilityEndedSubscriptions, abilityPerformedSubscriptions)
 	{
 		OnActivate = onActivate;
 		OnDeactivate = onDeactivate;

--- a/Game/Scripts/Models/Abilities/OtherActiveAbility.cs
+++ b/Game/Scripts/Models/Abilities/OtherActiveAbility.cs
@@ -11,8 +11,8 @@ public class OtherActiveAbility : ActiveAbility<OtherActiveAbility.State>
 	{
 	}
 
-	public Func<State, GDTask> OnActivate { get; protected set; }
-	public Func<State, GDTask> OnDeactivate { get; protected set; }
+	public Func<State, GDTask> OnActivate { get; private set; }
+	public Func<State, GDTask> OnDeactivate { get; private set; }
 
 	/// <summary>
 	/// A builder extending <see cref="ActiveAbility{T}.AbstractBuilder{TBuilder, TAbility}"/> with setter methods
@@ -26,7 +26,6 @@ public class OtherActiveAbility : ActiveAbility<OtherActiveAbility.State>
 		where TBuilder : AbstractBuilder<TBuilder, TAbility>
 		where TAbility : OtherActiveAbility, new()
 	{
-
 		public interface IOnActivateStep
 		{
 			IOnDeactivateStep WithOnActivate(Func<State, GDTask> onActivate);
@@ -63,7 +62,7 @@ public class OtherActiveAbility : ActiveAbility<OtherActiveAbility.State>
 	/// A convenience method that returns an instance of OtherActiveBuilder.
 	/// </summary>
 	/// <returns></returns>
-	public static AbstractBuilder<OtherActiveBuilder, OtherActiveAbility>.IOnActivateStep Builder()
+	public static OtherActiveBuilder.IOnActivateStep Builder()
 	{
 		return new OtherActiveBuilder();
 	}

--- a/Game/Scripts/Models/Abilities/OtherTargetedAbility.cs
+++ b/Game/Scripts/Models/Abilities/OtherTargetedAbility.cs
@@ -2,13 +2,62 @@
 using System.Collections.Generic;
 using Fractural.Tasks;
 
+/// <summary>
+/// A <see cref="TargetedAbility{T, TSingleTargetState}"/> that does not neatly fit any other dedicated ability implementation.
+/// </summary>
 public class OtherTargetedAbility : TargetedAbility<OtherTargetedAbility.State, SingleTargetState>
 {
 	public class State : TargetedAbilityState<SingleTargetState>
 	{
 	}
 
-	private readonly Func<State, Figure, GDTask> _onAfterConditionsApplied;
+	protected Func<State, Figure, GDTask> _onAfterConditionsApplied { get; set; }
+	
+	/// <summary>
+	/// A builder extending <see cref="TargetedAbility{T, TSingleTargetState}.AbstractBuilder{TBuilder, TAbility}"/> with setter methods
+	/// for values defined in OtherTargetedAbility. Enables inheritors of OtherTargetedAbility to further extend the builder.
+	/// </summary>
+	/// <typeparam name="TBuilder"></typeparam> Any builder extending this AbstractBuilder.
+	/// <typeparam name="TAbility"></typeparam> Any ability extending OtherTargetedAbility.
+	public new abstract class AbstractBuilder<TBuilder, TAbility> : TargetedAbility<State, SingleTargetState>.AbstractBuilder<TBuilder, TAbility>
+		where TBuilder : AbstractBuilder<TBuilder, TAbility>
+		where TAbility : OtherTargetedAbility, new()
+	{
+		public TBuilder WithOnAfterConditionsApplied(Func<State, Figure, GDTask> onAfterConditionsApplied)
+		{
+			Obj._onAfterConditionsApplied = onAfterConditionsApplied;
+			return (TBuilder)this;
+		}
+
+		/// <summary>
+		/// Overriding so we can set default values.
+		/// </summary>
+		public override TAbility Build()
+		{
+			Obj.Target = _target ?? Target.Allies;
+			return base.Build();
+		}
+	}
+
+	/// <summary>
+	/// A concrete implementation of the AbstractBuilder. Required to actually use the builder,
+	/// as abstract builders cannot be instantiated.
+	/// </summary>
+	public class OtherTargetedBuilder : AbstractBuilder<OtherTargetedBuilder, OtherTargetedAbility>
+	{
+		internal OtherTargetedBuilder() { }
+	}
+
+	/// <summary>
+	/// A convenience method that returns an instance of OtherTargetedBuilder.
+	/// </summary>
+	/// <returns></returns>
+	public static OtherTargetedBuilder Builder()
+	{
+		return new OtherTargetedBuilder();
+	}
+
+	public OtherTargetedAbility() { }
 
 	public OtherTargetedAbility(Func<State, Figure, GDTask> onAfterConditionsApplied = null, int targets = 1, int? range = null, RangeType? rangeType = null,
 		Target target = Target.Allies,

--- a/Game/Scripts/Models/Abilities/OtherTargetedAbility.cs
+++ b/Game/Scripts/Models/Abilities/OtherTargetedAbility.cs
@@ -11,8 +11,8 @@ public class OtherTargetedAbility : TargetedAbility<OtherTargetedAbility.State, 
 	{
 	}
 
-	protected Func<State, Figure, GDTask> _onAfterConditionsApplied { get; set; }
-	
+	private Func<State, Figure, GDTask> _onAfterConditionsApplied;
+
 	/// <summary>
 	/// A builder extending <see cref="TargetedAbility{T, TSingleTargetState}.AbstractBuilder{TBuilder, TAbility}"/> with setter methods
 	/// for values defined in OtherTargetedAbility. Enables inheritors of OtherTargetedAbility to further extend the builder.
@@ -59,7 +59,8 @@ public class OtherTargetedAbility : TargetedAbility<OtherTargetedAbility.State, 
 
 	public OtherTargetedAbility() { }
 
-	public OtherTargetedAbility(Func<State, Figure, GDTask> onAfterConditionsApplied = null, int targets = 1, int? range = null, RangeType? rangeType = null,
+	public OtherTargetedAbility(Func<State, Figure, GDTask> onAfterConditionsApplied = null, int targets = 1, int? range = null,
+		RangeType? rangeType = null,
 		Target target = Target.Allies,
 		bool requiresLineOfSight = true, bool mandatory = false,
 		Hex targetHex = null,

--- a/Game/Scripts/Models/Abilities/PullAbility.cs
+++ b/Game/Scripts/Models/Abilities/PullAbility.cs
@@ -2,11 +2,52 @@
 using System.Collections.Generic;
 using Fractural.Tasks;
 
+/// <summary>
+/// A forced movement <see cref="TargetedAbility{T, TSingleTargetState}"/> that moves the enemy towards the acting figure,
+/// ignoring most movement rules.
+/// </summary>
 public class PullAbility : TargetedAbility<PullAbility.State, SingleTargetState>
 {
 	public class State : TargetedAbilityState<SingleTargetState>
 	{
 	}
+	
+	/// <summary>
+	/// A builder extending <see cref="TargetedAbility{T, TSingleTargetState}.AbstractBuilder{TBuilder, TAbility}"/> with setter methods
+	/// for values defined in PullAbility. Enables inheritors of PullAbility to further extend the builder.
+	/// </summary>
+	/// <typeparam name="TBuilder"></typeparam> Any builder extending this AbstractBuilder.
+	/// <typeparam name="TAbility"></typeparam> Any ability extending PullAbility.
+	public new abstract class AbstractBuilder<TBuilder, TAbility> : TargetedAbility<State, SingleTargetState>.AbstractBuilder<TBuilder, TAbility>,
+		AbstractBuilder<TBuilder, TAbility>.IPullStep
+		where TBuilder : AbstractBuilder<TBuilder, TAbility>
+		where TAbility : PullAbility, new()
+	{
+		public interface IPullStep
+		{
+			TBuilder WithPull(int push);
+		}
+	}
+
+	/// <summary>
+	/// A concrete implementation of the AbstractBuilder. Required to actually use the builder,
+	/// as abstract builders cannot be instantiated.
+	/// </summary>
+	public class PullBuilder : AbstractBuilder<PullBuilder, PullAbility>
+	{
+		internal PullBuilder() { }
+	}
+
+	/// <summary>
+	/// A convenience method that returns an instance of PullBuilder.
+	/// </summary>
+	/// <returns></returns>
+	public static PullBuilder.IPullStep Builder()
+	{
+		return new PullBuilder();
+	}
+
+	public PullAbility() { }
 
 	public PullAbility(int pull, int targets = 1, int? range = null, RangeType? rangeType = null,
 		Target target = Target.Enemies,

--- a/Game/Scripts/Models/Abilities/PullAbility.cs
+++ b/Game/Scripts/Models/Abilities/PullAbility.cs
@@ -11,7 +11,7 @@ public class PullAbility : TargetedAbility<PullAbility.State, SingleTargetState>
 	public class State : TargetedAbilityState<SingleTargetState>
 	{
 	}
-	
+
 	/// <summary>
 	/// A builder extending <see cref="TargetedAbility{T, TSingleTargetState}.AbstractBuilder{TBuilder, TAbility}"/> with setter methods
 	/// for values defined in PullAbility. Enables inheritors of PullAbility to further extend the builder.

--- a/Game/Scripts/Models/Abilities/PushAbility.cs
+++ b/Game/Scripts/Models/Abilities/PushAbility.cs
@@ -2,11 +2,52 @@
 using System.Collections.Generic;
 using Fractural.Tasks;
 
+/// <summary>
+/// A forced movement <see cref="TargetedAbility{T, TSingleTargetState}"/> that moves the enemy away from the acting figure,
+/// ignoring most movement rules.
+/// </summary>
 public class PushAbility : TargetedAbility<PushAbility.State, SingleTargetState>
 {
 	public class State : TargetedAbilityState<SingleTargetState>
 	{
 	}
+
+	/// <summary>
+	/// A builder extending <see cref="TargetedAbility{T, TSingleTargetState}.AbstractBuilder{TBuilder, TAbility}"/> with setter methods
+	/// for values defined in PushAbility. Enables inheritors of PushAbility to further extend the builder.
+	/// </summary>
+	/// <typeparam name="TBuilder"></typeparam> Any builder extending this AbstractBuilder.
+	/// <typeparam name="TAbility"></typeparam> Any ability extending PushAbility.
+	public new abstract class AbstractBuilder<TBuilder, TAbility> : TargetedAbility<State, SingleTargetState>.AbstractBuilder<TBuilder, TAbility>,
+		AbstractBuilder<TBuilder, TAbility>.IPushStep
+		where TBuilder : AbstractBuilder<TBuilder, TAbility>
+		where TAbility : PushAbility, new()
+	{
+		public interface IPushStep
+		{
+			TBuilder WithPush(int push);
+		}
+	}
+
+	/// <summary>
+	/// A concrete implementation of the AbstractBuilder. Required to actually use the builder,
+	/// as abstract builders cannot be instantiated.
+	/// </summary>
+	public class PushBuilder : AbstractBuilder<PushBuilder, PushAbility>
+	{
+		internal PushBuilder() { }
+	}
+
+	/// <summary>
+	/// A convenience method that returns an instance of PushBuilder.
+	/// </summary>
+	/// <returns></returns>
+	public static AbstractBuilder<PushBuilder, PushAbility>.IPushStep Builder()
+	{
+		return new PushBuilder();
+	}
+
+	public PushAbility() { }
 
 	public PushAbility(int push, int targets = 1, int? range = null, RangeType? rangeType = null,
 		Target target = Target.Enemies,
@@ -17,8 +58,8 @@ public class PushAbility : TargetedAbility<PushAbility.State, SingleTargetState>
 		Func<State, GDTask> onAbilityStarted = null, Func<State, GDTask> onAbilityEnded = null, Func<State, GDTask> onAbilityEndedPerformed = null,
 		ConditionalAbilityCheckDelegate conditionalAbilityCheck = null,
 		Func<State, string> getTargetingHintText = null,
-		List<ScenarioEvents.AbilityStarted.Subscription> abilityStartedSubscriptions = null,
-		List<ScenarioEvents.AbilityEnded.Subscription> abilityEndedSubscriptions = null,
+		List<ScenarioEvent<ScenarioEvents.AbilityStarted.Parameters>.Subscription> abilityStartedSubscriptions = null,
+		List<ScenarioEvent<ScenarioEvents.AbilityEnded.Parameters>.Subscription> abilityEndedSubscriptions = null,
 		List<ScenarioEvent<ScenarioEvents.AbilityPerformed.Parameters>.Subscription> abilityPerformedSubscriptions = null)
 		: base(targets, range, rangeType, target,
 			requiresLineOfSight, mandatory, targetHex, aoePattern, push, pull, conditions,

--- a/Game/Scripts/Models/Abilities/PushAbility.cs
+++ b/Game/Scripts/Models/Abilities/PushAbility.cs
@@ -42,7 +42,7 @@ public class PushAbility : TargetedAbility<PushAbility.State, SingleTargetState>
 	/// A convenience method that returns an instance of PushBuilder.
 	/// </summary>
 	/// <returns></returns>
-	public static AbstractBuilder<PushBuilder, PushAbility>.IPushStep Builder()
+	public static PushBuilder.IPushStep Builder()
 	{
 		return new PushBuilder();
 	}

--- a/Game/Scripts/Models/Abilities/RetaliateAbility.cs
+++ b/Game/Scripts/Models/Abilities/RetaliateAbility.cs
@@ -2,6 +2,9 @@
 using System.Collections.Generic;
 using Fractural.Tasks;
 
+/// <summary>
+/// An <see cref="ActiveAbility{T}"/> that deals direct damage to those that attacked the owner of the ability at a given range.
+/// </summary>
 public class RetaliateAbility : ActiveAbility<RetaliateAbility.State>
 {
 	public class State : ActiveAbilityState
@@ -20,17 +23,68 @@ public class RetaliateAbility : ActiveAbility<RetaliateAbility.State>
 		}
 	}
 
-	public int RetaliateValue { get; }
-	public int Range { get; }
+	public int RetaliateValue { get; protected set; }
+	public int Range { get; protected set; }
+
+	/// <summary>
+	/// A builder extending <see cref="ActiveAbility{T}.AbstractBuilder{TBuilder, TAbility}"/> with setter methods
+	/// for values defined in RetaliateAbility. Enables inheritors of RetaliateAbility to further extend the builder.
+	/// </summary>
+	/// <typeparam name="TBuilder"></typeparam> Any builder extending this AbstractBuilder.
+	/// <typeparam name="TAbility"></typeparam> Any ability extending RetaliateAbility.
+	public new class AbstractBuilder<TBuilder, TAbility> : ActiveAbility<State>.AbstractBuilder<TBuilder, TAbility>,
+		AbstractBuilder<TBuilder, TAbility>.IRetaliateValueStep
+		where TBuilder : AbstractBuilder<TBuilder, TAbility>
+		where TAbility : RetaliateAbility, new()
+	{
+
+		public interface IRetaliateValueStep
+		{
+			TBuilder WithRetaliateValue(int retaliateValue);
+		}
+
+		public TBuilder WithRetaliateValue(int retaliateValue)
+		{
+			Obj.RetaliateValue = retaliateValue;
+			return (TBuilder)this;
+		}
+
+		public TBuilder WithRange(int range)
+		{
+			Obj.Range = range;
+			return (TBuilder)this;
+		}
+	}
+
+	/// <summary>
+	/// A concrete implementation of the AbstractBuilder. Required to actually use the builder,
+	/// as abstract builders cannot be instantiated.
+	/// </summary>
+	public class RetaliateBuilder : AbstractBuilder<RetaliateBuilder, RetaliateAbility>
+	{
+		internal RetaliateBuilder() { }
+	}
+
+	/// <summary>
+	/// A convenience method that returns an instance of RetaliateBuilder.
+	/// </summary>
+	/// <returns></returns>
+	public static AbstractBuilder<RetaliateBuilder, RetaliateAbility>.IRetaliateValueStep Builder()
+	{
+		return new RetaliateBuilder();
+	}
+
+	public RetaliateAbility() { }
 
 	public RetaliateAbility(int retaliateValue, int range = 1,
 		Func<State, GDTask> onAbilityStarted = null, Func<State, GDTask> onAbilityEnded = null, Func<State, GDTask> onAbilityEndedPerformed = null,
 		ConditionalAbilityCheckDelegate conditionalAbilityCheck = null,
 		Func<State, string> getHintText = null,
-		List<ScenarioEvents.AbilityStarted.Subscription> abilityStartedSubscriptions = null,
-		List<ScenarioEvents.AbilityEnded.Subscription> abilityEndedSubscriptions = null,
+		List<ScenarioEvent<ScenarioEvents.AbilityStarted.Parameters>.Subscription> abilityStartedSubscriptions = null,
+		List<ScenarioEvent<ScenarioEvents.AbilityEnded.Parameters>.Subscription> abilityEndedSubscriptions = null,
 		List<ScenarioEvent<ScenarioEvents.AbilityPerformed.Parameters>.Subscription> abilityPerformedSubscriptions = null)
-		: base(onAbilityStarted, onAbilityEnded, onAbilityEndedPerformed, conditionalAbilityCheck, getHintText, abilityStartedSubscriptions, abilityEndedSubscriptions, abilityPerformedSubscriptions)
+		: base(onAbilityStarted, onAbilityEnded, onAbilityEndedPerformed, conditionalAbilityCheck, getHintText, abilityStartedSubscriptions,
+			abilityEndedSubscriptions, abilityPerformedSubscriptions)
 	{
 		RetaliateValue = retaliateValue;
 		Range = range;

--- a/Game/Scripts/Models/Abilities/RetaliateAbility.cs
+++ b/Game/Scripts/Models/Abilities/RetaliateAbility.cs
@@ -23,8 +23,8 @@ public class RetaliateAbility : ActiveAbility<RetaliateAbility.State>
 		}
 	}
 
-	public int RetaliateValue { get; protected set; }
-	public int Range { get; protected set; }
+	public int RetaliateValue { get; private set; }
+	public int Range { get; private set; }
 
 	/// <summary>
 	/// A builder extending <see cref="ActiveAbility{T}.AbstractBuilder{TBuilder, TAbility}"/> with setter methods
@@ -37,7 +37,6 @@ public class RetaliateAbility : ActiveAbility<RetaliateAbility.State>
 		where TBuilder : AbstractBuilder<TBuilder, TAbility>
 		where TAbility : RetaliateAbility, new()
 	{
-
 		public interface IRetaliateValueStep
 		{
 			TBuilder WithRetaliateValue(int retaliateValue);

--- a/Game/Scripts/Models/Abilities/ShieldAbility.cs
+++ b/Game/Scripts/Models/Abilities/ShieldAbility.cs
@@ -2,30 +2,102 @@
 using System.Collections.Generic;
 using Fractural.Tasks;
 
+/// <summary>
+/// An <see cref="ActiveAbility{T}"/> that reduces the damage suffered from attacks.
+/// </summary>
 public class ShieldAbility : ActiveAbility<ShieldAbility.State>
 {
 	public class State : ActiveAbilityState
 	{
 	}
 
-	private readonly Func<ScenarioEvents.SufferDamage.Parameters, bool> _customCanApply;
-	private readonly bool _customCanApplyReplaceFully;
+	protected Func<ScenarioEvents.SufferDamage.Parameters, bool> _customCanApply { get; set; }
+	protected bool _customCanApplyReplaceFully { get; set; }
 
-	public DynamicInt<State> ShieldValue { get; }
-	public RangeType? RequiredRangeType { get; }
-	public bool Pierceable { get; }
+	public DynamicInt<State> ShieldValue { get; protected set; }
+	public RangeType? RequiredRangeType { get; protected set; }
+	public bool Pierceable { get; protected set; } = true;
 
 	public bool ConditionalValue => RequiredRangeType.HasValue || _customCanApply != null;
+
+	/// <summary>
+	/// A builder extending <see cref="ActiveAbility{T}.AbstractBuilder{TBuilder, TAbility}"/> with setter methods
+	/// for values defined in ShieldAbility. Enables inheritors of ShieldAbility to further extend the builder.
+	/// </summary>
+	/// <typeparam name="TBuilder"></typeparam> Any builder extending this AbstractBuilder.
+	/// <typeparam name="TAbility"></typeparam> Any ability extending ShieldAbility.
+	public new class AbstractBuilder<TBuilder, TAbility> : ActiveAbility<State>.AbstractBuilder<TBuilder, TAbility>,
+		AbstractBuilder<TBuilder, TAbility>.IShieldValueStep
+		where TBuilder : AbstractBuilder<TBuilder, TAbility>
+		where TAbility : ShieldAbility, new()
+	{
+
+		public interface IShieldValueStep
+		{
+			TBuilder WithShieldValue(DynamicInt<State> shieldValue);
+		}
+
+		public TBuilder WithCustomCanApply(Func<ScenarioEvents.SufferDamage.Parameters, bool> customCanApply)
+		{
+			Obj._customCanApply = customCanApply;
+			return (TBuilder)this;
+		}
+
+		public TBuilder WithCustomCanApplyReplaceFully(bool customCanApplyReplaceFully)
+		{
+			Obj._customCanApplyReplaceFully = customCanApplyReplaceFully;
+			return (TBuilder)this;
+		}
+
+		public TBuilder WithShieldValue(DynamicInt<State> shieldValue)
+		{
+			Obj.ShieldValue = shieldValue;
+			return (TBuilder)this;
+		}
+
+		public TBuilder WithRequiredRangeType(RangeType rangeType)
+		{
+			Obj.RequiredRangeType = rangeType;
+			return (TBuilder)this;
+		}
+
+		public TBuilder WithPierceable(bool pierceable)
+		{
+			Obj.Pierceable = pierceable;
+			return (TBuilder)this;
+		}
+	}
+
+	/// <summary>
+	/// A concrete implementation of the AbstractBuilder. Required to actually use the builder,
+	/// as abstract builders cannot be instantiated.
+	/// </summary>
+	public class ShieldBuilder : AbstractBuilder<ShieldBuilder, ShieldAbility>
+	{
+		internal ShieldBuilder() { }
+	}
+
+	/// <summary>
+	/// A convenience method that returns an instance of ShieldBuilder.
+	/// </summary>
+	/// <returns></returns>
+	public static AbstractBuilder<ShieldBuilder, ShieldAbility>.IShieldValueStep Builder()
+	{
+		return new ShieldBuilder();
+	}
+
+	public ShieldAbility() { }
 
 	public ShieldAbility(DynamicInt<State> shieldValue, RangeType? requiredRangeType = null, bool pierceable = true,
 		Func<ScenarioEvents.SufferDamage.Parameters, bool> customCanApply = null, bool customCanApplyReplaceFully = false,
 		Func<State, GDTask> onAbilityStarted = null, Func<State, GDTask> onAbilityEnded = null, Func<State, GDTask> onAbilityEndedPerformed = null,
 		ConditionalAbilityCheckDelegate conditionalAbilityCheck = null,
 		Func<State, string> getHintText = null,
-		List<ScenarioEvents.AbilityStarted.Subscription> abilityStartedSubscriptions = null,
-		List<ScenarioEvents.AbilityEnded.Subscription> abilityEndedSubscriptions = null,
+		List<ScenarioEvent<ScenarioEvents.AbilityStarted.Parameters>.Subscription> abilityStartedSubscriptions = null,
+		List<ScenarioEvent<ScenarioEvents.AbilityEnded.Parameters>.Subscription> abilityEndedSubscriptions = null,
 		List<ScenarioEvent<ScenarioEvents.AbilityPerformed.Parameters>.Subscription> abilityPerformedSubscriptions = null)
-		: base(onAbilityStarted, onAbilityEnded, onAbilityEndedPerformed, conditionalAbilityCheck, getHintText, abilityStartedSubscriptions, abilityEndedSubscriptions, abilityPerformedSubscriptions)
+		: base(onAbilityStarted, onAbilityEnded, onAbilityEndedPerformed, conditionalAbilityCheck, getHintText, abilityStartedSubscriptions,
+			abilityEndedSubscriptions, abilityPerformedSubscriptions)
 	{
 		ShieldValue = shieldValue;
 		RequiredRangeType = requiredRangeType;

--- a/Game/Scripts/Models/Abilities/ShieldAbility.cs
+++ b/Game/Scripts/Models/Abilities/ShieldAbility.cs
@@ -11,12 +11,12 @@ public class ShieldAbility : ActiveAbility<ShieldAbility.State>
 	{
 	}
 
-	protected Func<ScenarioEvents.SufferDamage.Parameters, bool> _customCanApply { get; set; }
-	protected bool _customCanApplyReplaceFully { get; set; }
+	private Func<ScenarioEvents.SufferDamage.Parameters, bool> _customCanApply;
+	private bool _customCanApplyReplaceFully;
 
-	public DynamicInt<State> ShieldValue { get; protected set; }
-	public RangeType? RequiredRangeType { get; protected set; }
-	public bool Pierceable { get; protected set; } = true;
+	public DynamicInt<State> ShieldValue { get; private set; }
+	public RangeType? RequiredRangeType { get; private set; }
+	public bool Pierceable { get; private set; } = true;
 
 	public bool ConditionalValue => RequiredRangeType.HasValue || _customCanApply != null;
 
@@ -31,7 +31,6 @@ public class ShieldAbility : ActiveAbility<ShieldAbility.State>
 		where TBuilder : AbstractBuilder<TBuilder, TAbility>
 		where TAbility : ShieldAbility, new()
 	{
-
 		public interface IShieldValueStep
 		{
 			TBuilder WithShieldValue(DynamicInt<State> shieldValue);
@@ -81,7 +80,7 @@ public class ShieldAbility : ActiveAbility<ShieldAbility.State>
 	/// A convenience method that returns an instance of ShieldBuilder.
 	/// </summary>
 	/// <returns></returns>
-	public static AbstractBuilder<ShieldBuilder, ShieldAbility>.IShieldValueStep Builder()
+	public static ShieldBuilder.IShieldValueStep Builder()
 	{
 		return new ShieldBuilder();
 	}

--- a/Game/Scripts/Models/Abilities/SummonAbility.cs
+++ b/Game/Scripts/Models/Abilities/SummonAbility.cs
@@ -19,10 +19,10 @@ public class SummonAbility : ActiveAbility<SummonAbility.State>
 		}
 	}
 
-	protected SummonStats SummonStats { get; set; }
-	protected string Name { get; set; }
-	protected string TexturePath { get; set; }
-	protected Action<State, List<Hex>> GetValidHexes { get; set; }
+	private SummonStats _summonStats;
+	private string _name;
+	private string _texturePath;
+	private Action<State, List<Hex>> _getValidHexes;
 
 	/// <summary>
 	/// A builder extending <see cref="ActiveAbility{T}.AbstractBuilder{TBuilder, TAbility}"/> with setter methods
@@ -37,7 +37,6 @@ public class SummonAbility : ActiveAbility<SummonAbility.State>
 		where TBuilder : AbstractBuilder<TBuilder, TAbility>
 		where TAbility : SummonAbility, new()
 	{
-
 		public interface ISummonStatsStep
 		{
 			INameStep WithSummonStats(SummonStats summonStats);
@@ -55,26 +54,26 @@ public class SummonAbility : ActiveAbility<SummonAbility.State>
 
 		public INameStep WithSummonStats(SummonStats summonStats)
 		{
-			Obj.SummonStats = summonStats;
+			Obj._summonStats = summonStats;
 			return (TBuilder)this;
 		}
 
 		public ITexturePathStep WithName(string name)
 		{
-			Obj.Name = name;
+			Obj._name = name;
 			return (TBuilder)this;
 		}
 
 		public TBuilder WithTexturePath(string texturePath)
 		{
-			Obj.TexturePath = texturePath;
+			Obj._texturePath = texturePath;
 			return (TBuilder)this;
 		}
 
 		public TBuilder WithGetValidHexes(
 			Action<State, List<Hex>> getValidHexes)
 		{
-			Obj.GetValidHexes = getValidHexes;
+			Obj._getValidHexes = getValidHexes;
 			return (TBuilder)this;
 		}
 	}
@@ -92,7 +91,7 @@ public class SummonAbility : ActiveAbility<SummonAbility.State>
 	/// A convenience method that returns an instance of SummonBuilder.
 	/// </summary>
 	/// <returns></returns>
-	public static AbstractBuilder<SummonBuilder, SummonAbility>.ISummonStatsStep Builder()
+	public static SummonBuilder.ISummonStatsStep Builder()
 	{
 		return new SummonBuilder();
 	}
@@ -109,10 +108,10 @@ public class SummonAbility : ActiveAbility<SummonAbility.State>
 		: base(onAbilityStarted, onAbilityEnded, onAbilityEndedPerformed, conditionalAbilityCheck, getHintText, abilityStartedSubscriptions,
 			abilityEndedSubscriptions, abilityPerformedSubscriptions)
 	{
-		SummonStats = summonStats;
-		Name = name;
-		TexturePath = texturePath;
-		GetValidHexes = getValidHexes;
+		_summonStats = summonStats;
+		_name = name;
+		_texturePath = texturePath;
+		_getValidHexes = getValidHexes;
 	}
 
 	protected override async GDTask Perform(State abilityState)
@@ -120,7 +119,7 @@ public class SummonAbility : ActiveAbility<SummonAbility.State>
 		// Target a hex within range
 		Hex targetedHex = await AbilityCmd.SelectHex(abilityState, list =>
 		{
-			if(GetValidHexes == null)
+			if(_getValidHexes == null)
 			{
 				RangeHelper.FindHexesInRange(abilityState.Performer.Hex, 1, true, list);
 
@@ -136,7 +135,7 @@ public class SummonAbility : ActiveAbility<SummonAbility.State>
 			}
 			else
 			{
-				GetValidHexes(abilityState, list);
+				_getValidHexes(abilityState, list);
 			}
 		});
 
@@ -146,7 +145,7 @@ public class SummonAbility : ActiveAbility<SummonAbility.State>
 			Summon summon = summonScene.Instantiate<Summon>();
 			GameController.Instance.Map.AddChild(summon);
 			await summon.Init(targetedHex);
-			summon.Spawn(SummonStats, (Character)abilityState.Performer, Name, TexturePath);
+			summon.Spawn(_summonStats, (Character)abilityState.Performer, _name, _texturePath);
 			abilityState.SetSummon(summon);
 
 			summon.Scale = Vector2.Zero;

--- a/Game/Scripts/Models/Abilities/TargetedAbility.cs
+++ b/Game/Scripts/Models/Abilities/TargetedAbility.cs
@@ -157,29 +157,137 @@ public abstract class TargetedAbilityState : AbilityState
 	}
 }
 
+/// <summary>
+/// An <see cref="Ability{T}"/> that is considered a targeted ability as per the rules; that targets a specific figure.
+/// </summary>
 public abstract class TargetedAbility<T, TSingleTargetState> : Ability<T>
 	where T : TargetedAbilityState<TSingleTargetState>, new()
 	where TSingleTargetState : SingleTargetState, new()
 {
 	private static readonly List<Hex> HexCache = new List<Hex>();
 
-	private Func<T, string> _getTargetingHintText;
+	private Func<T, string> GetTargetingHintText { get; set; }
 
-	public int Targets { get; }
-	public int Range { get; }
-	public RangeType RangeType { get; }
-	public Target Target { get; }
+	public int Range { get; protected set; } = 1;
+	public RangeType RangeType { get; protected set; } = RangeType.Melee;
+	public bool RequiresLineOfSight { get; protected set; } = true;
+	public Target Target { get; protected set; } = Target.Enemies;
+	public int Targets { get; protected set; } = 1;
+	public Hex TargetHex { get; protected set; }
+	public AOEPattern AOEPattern { get; protected set; }
+	public bool Mandatory { get; protected set; }
+	public int Push { get; protected set; }
+	public int Pull { get; protected set; }
 
-	public bool RequiresLineOfSight { get; }
-	public bool Mandatory { get; }
-	public Hex TargetHex { get; }
-	public AOEPattern AOEPattern { get; }
-	public int Push { get; }
-	public int Pull { get; }
+	public ConditionModel[] Conditions { get; protected set; } = [];
 
-	public ConditionModel[] Conditions { get; }
+	public Action<T, List<Figure>> CustomGetTargets { get; protected set; }
 
-	public Action<T, List<Figure>> CustomGetTargets { get; }
+	/// <summary>
+	/// A builder extending <see cref="Ability{T}.AbstractBuilder{TBuilder, TAbility}"/> with setter methods
+	/// for values defined in TargetedAbility. Enables inheritors of TargetedAbility to further extend the builder.
+	/// </summary>
+	/// <typeparam name="TBuilder"></typeparam> Any builder extending this AbstractBuilder.
+	/// <typeparam name="TAbility"></typeparam> Any ability extending TargetedAbility.
+	public new class AbstractBuilder<TBuilder, TAbility> : Ability<T>.AbstractBuilder<TBuilder, TAbility>
+		where TBuilder : AbstractBuilder<TBuilder, TAbility>
+		where TAbility : TargetedAbility<T, TSingleTargetState>, new()
+	{
+
+		protected Target? _target;
+		protected Func<T, string> GetTargetingHintText;
+
+		public TBuilder WithGetTargetingHintText(Func<T, string> getTargetingHintText)
+		{
+			GetTargetingHintText = getTargetingHintText;
+			Obj.GetTargetingHintText = getTargetingHintText;
+			return (TBuilder)this;
+		}
+
+		public TBuilder WithRange(int range)
+		{
+			Obj.Range = range;
+			return (TBuilder)this;
+		}
+
+		public TBuilder WithRangeType(RangeType rangeType)
+		{
+			Obj.RangeType = rangeType;
+			return (TBuilder)this;
+		}
+
+		public TBuilder WithRequiresLineOfSight(bool requiresLineOfSight)
+		{
+			Obj.RequiresLineOfSight = requiresLineOfSight;
+			return (TBuilder)this;
+		}
+
+		public TBuilder WithTarget(Target target)
+		{
+			_target = target;
+			Obj.Target = target;
+			return (TBuilder)this;
+		}
+
+		public TBuilder WithTargets(int targets)
+		{
+			Obj.Targets = targets;
+			return (TBuilder)this;
+		}
+
+		public TBuilder WithTargetHex(Hex targetHex)
+		{
+			Obj.TargetHex = targetHex;
+			return (TBuilder)this;
+		}
+
+		public TBuilder WithAOEPattern(AOEPattern aoePattern)
+		{
+			Obj.AOEPattern = aoePattern;
+			return (TBuilder)this;
+		}
+
+		public TBuilder WithMandatory(bool mandatory)
+		{
+			Obj.Mandatory = mandatory;
+			return (TBuilder)this;
+		}
+
+		public TBuilder WithPush(int push)
+		{
+			Obj.Push = push;
+			return (TBuilder)this;
+		}
+
+		public TBuilder WithPull(int pull)
+		{
+			Obj.Pull = pull;
+			return (TBuilder)this;
+		}
+
+		public TBuilder WithConditions(params ConditionModel[] conditions)
+		{
+			Obj.Conditions = conditions;
+			return (TBuilder)this;
+		}
+
+		public TBuilder WithCustomGetTargets(Action<T, List<Figure>> getTargets)
+		{
+			Obj.CustomGetTargets = getTargets;
+			return (TBuilder)this;
+		}
+
+		/// <summary>
+		/// Overriding so we can set default values.
+		/// </summary>
+		public override TAbility Build()
+		{
+			Obj.GetTargetingHintText = GetTargetingHintText ?? Obj.DefaultTargetingHintText;
+			return base.Build();
+		}
+	}
+
+	public TargetedAbility() { }
 
 	public TargetedAbility(int targets = 1, int? range = null, RangeType? rangeType = null,
 		Target target = Target.Enemies,
@@ -190,10 +298,11 @@ public abstract class TargetedAbility<T, TSingleTargetState> : Ability<T>
 		Func<T, GDTask> onAbilityStarted = null, Func<T, GDTask> onAbilityEnded = null, Func<T, GDTask> onAbilityEndedPerformed = null,
 		ConditionalAbilityCheckDelegate conditionalAbilityCheck = null,
 		Func<T, string> getTargetingHintText = null,
-		List<ScenarioEvents.AbilityStarted.Subscription> abilityStartedSubscriptions = null,
-		List<ScenarioEvents.AbilityEnded.Subscription> abilityEndedSubscriptions = null,
+		List<ScenarioEvent<ScenarioEvents.AbilityStarted.Parameters>.Subscription> abilityStartedSubscriptions = null,
+		List<ScenarioEvent<ScenarioEvents.AbilityEnded.Parameters>.Subscription> abilityEndedSubscriptions = null,
 		List<ScenarioEvent<ScenarioEvents.AbilityPerformed.Parameters>.Subscription> abilityPerformedSubscriptions = null)
-		: base(onAbilityStarted, onAbilityEnded, onAbilityEndedPerformed, conditionalAbilityCheck, abilityStartedSubscriptions, abilityEndedSubscriptions, abilityPerformedSubscriptions)
+		: base(onAbilityStarted, onAbilityEnded, onAbilityEndedPerformed, conditionalAbilityCheck, abilityStartedSubscriptions,
+			abilityEndedSubscriptions, abilityPerformedSubscriptions)
 	{
 		Targets = targets;
 		Range = range ?? 1;
@@ -209,7 +318,7 @@ public abstract class TargetedAbility<T, TSingleTargetState> : Ability<T>
 
 		Conditions = conditions ?? [];
 		CustomGetTargets = customGetTargets;
-		_getTargetingHintText = getTargetingHintText ?? DefaultTargetingHintText;
+		GetTargetingHintText = getTargetingHintText ?? DefaultTargetingHintText;
 	}
 
 	protected override void InitializeState(T abilityState)
@@ -254,7 +363,8 @@ public abstract class TargetedAbility<T, TSingleTargetState> : Ability<T>
 			if(abilityState.Authority is Character)
 			{
 				AOEPrompt.Answer aoeAnswer =
-					await PromptManager.Prompt(new AOEPrompt(abilityState, AOEPattern, TargetHex, null, () => "Select where to target"), abilityState.Authority);
+					await PromptManager.Prompt(new AOEPrompt(abilityState, AOEPattern, TargetHex, null, () => "Select where to target"),
+						abilityState.Authority);
 
 				if(aoeAnswer.Skipped)
 				{
@@ -271,7 +381,8 @@ public abstract class TargetedAbility<T, TSingleTargetState> : Ability<T>
 				Figure focus = await abilityState.ActionState.GetFocus();
 				MonsterAOEPrompt.Answer aoeAnswer =
 					await PromptManager.Prompt(
-						new MonsterAOEPrompt(abilityState, AOEPattern, abilityState.AbilityRange, abilityState.AbilityRangeType, focus, null, () => "Select where to target"), abilityState.Authority);
+						new MonsterAOEPrompt(abilityState, AOEPattern, abilityState.AbilityRange, abilityState.AbilityRangeType, focus, null,
+							() => "Select where to target"), abilityState.Authority);
 
 				if(aoeAnswer.Skipped)
 				{
@@ -360,7 +471,8 @@ public abstract class TargetedAbility<T, TSingleTargetState> : Ability<T>
 					remove = true;
 				}
 
-				if(Target.HasFlag(Target.MustTargetSameWithAllTargets) && abilityState.UniqueTargetedFigures.Count > 0 && abilityState.UniqueTargetedFigures[0] != figure)
+				if(Target.HasFlag(Target.MustTargetSameWithAllTargets) && abilityState.UniqueTargetedFigures.Count > 0 &&
+				   abilityState.UniqueTargetedFigures[0] != figure)
 				{
 					remove = true;
 				}
@@ -412,7 +524,8 @@ public abstract class TargetedAbility<T, TSingleTargetState> : Ability<T>
 			{
 				bool autoSelectIfOne = Mandatory || (customTargets != null && customTargets.Count == 1) || (TargetHex != null && AOEPattern == null);
 				TargetSelectionPrompt.Answer targetAnswer = await PromptManager.Prompt(
-					new TargetSelectionPrompt(getValidTargets, autoSelectIfOne, Mandatory, duringTargetedAbilityEffectCollection, () => _getTargetingHintText(abilityState)), abilityState.Authority);
+					new TargetSelectionPrompt(getValidTargets, autoSelectIfOne, Mandatory, duringTargetedAbilityEffectCollection,
+						() => GetTargetingHintText(abilityState)), abilityState.Authority);
 
 				if(targetAnswer.Skipped)
 				{
@@ -427,7 +540,8 @@ public abstract class TargetedAbility<T, TSingleTargetState> : Ability<T>
 				//Figure focus = bestFocusNodes.Count > 0 ? bestFocusNodes[0].Focus : null;
 				Figure focus = await abilityState.ActionState.GetFocus();
 				MonsterTargetSelectionPrompt.Answer targetAnswer = await PromptManager.Prompt(
-					new MonsterTargetSelectionPrompt(getValidTargets, true, focus, duringTargetedAbilityEffectCollection, () => _getTargetingHintText(abilityState)), abilityState.Authority);
+					new MonsterTargetSelectionPrompt(getValidTargets, true, focus, duringTargetedAbilityEffectCollection,
+						() => GetTargetingHintText(abilityState)), abilityState.Authority);
 
 				if(targetAnswer.Skipped)
 				{
@@ -459,13 +573,15 @@ public abstract class TargetedAbility<T, TSingleTargetState> : Ability<T>
 			// Pull
 			if(!performer.IsDestroyed && !target.IsDestroyed && abilityState.SingleTargetPull > 0)
 			{
-				await PushPull(abilityState, performer.Hex, target, abilityState.SingleTargetPull, false, () => $"Select a path to {Icons.HintText(Icons.Pull)}{abilityState.SingleTargetPull} target");
+				await PushPull(abilityState, performer.Hex, target, abilityState.SingleTargetPull, false,
+					() => $"Select a path to {Icons.HintText(Icons.Pull)}{abilityState.SingleTargetPull} target");
 			}
 
 			// Push
 			if(!performer.IsDestroyed && !target.IsDestroyed && abilityState.SingleTargetPush > 0)
 			{
-				await PushPull(abilityState, performer.Hex, target, abilityState.SingleTargetPush, true, () => $"Select a path to {Icons.HintText(Icons.Push)}{abilityState.SingleTargetPush} target");
+				await PushPull(abilityState, performer.Hex, target, abilityState.SingleTargetPush, true,
+					() => $"Select a path to {Icons.HintText(Icons.Push)}{abilityState.SingleTargetPush} target");
 			}
 
 			await AfterEffects(abilityState, target);

--- a/Game/Scripts/Models/Abilities/TargetedAbility.cs
+++ b/Game/Scripts/Models/Abilities/TargetedAbility.cs
@@ -158,7 +158,7 @@ public abstract class TargetedAbilityState : AbilityState
 }
 
 /// <summary>
-/// An <see cref="Ability{T}"/> that is considered a targeted ability as per the rules; that targets a specific figure.
+/// An <see cref="Ability{T}"/> that is considered a targeted ability as per the rules; that targets figures with given restrictions.
 /// </summary>
 public abstract class TargetedAbility<T, TSingleTargetState> : Ability<T>
 	where T : TargetedAbilityState<TSingleTargetState>, new()
@@ -166,22 +166,22 @@ public abstract class TargetedAbility<T, TSingleTargetState> : Ability<T>
 {
 	private static readonly List<Hex> HexCache = new List<Hex>();
 
-	private Func<T, string> GetTargetingHintText { get; set; }
+	private Func<T, string> _getTargetingHintText;
 
-	public int Range { get; protected set; } = 1;
-	public RangeType RangeType { get; protected set; } = RangeType.Melee;
-	public bool RequiresLineOfSight { get; protected set; } = true;
+	public int Range { get; private set; } = 1;
+	public RangeType RangeType { get; private set; } = RangeType.Melee;
+	public bool RequiresLineOfSight { get; private set; } = true;
 	public Target Target { get; protected set; } = Target.Enemies;
-	public int Targets { get; protected set; } = 1;
-	public Hex TargetHex { get; protected set; }
-	public AOEPattern AOEPattern { get; protected set; }
-	public bool Mandatory { get; protected set; }
-	public int Push { get; protected set; }
-	public int Pull { get; protected set; }
+	public int Targets { get; private set; } = 1;
+	public Hex TargetHex { get; private set; }
+	public AOEPattern AOEPattern { get; private set; }
+	public bool Mandatory { get; private set; }
+	public int Push { get; private set; }
+	public int Pull { get; private set; }
 
-	public ConditionModel[] Conditions { get; protected set; } = [];
+	public ConditionModel[] Conditions { get; private set; } = [];
 
-	public Action<T, List<Figure>> CustomGetTargets { get; protected set; }
+	public Action<T, List<Figure>> CustomGetTargets { get; private set; }
 
 	/// <summary>
 	/// A builder extending <see cref="Ability{T}.AbstractBuilder{TBuilder, TAbility}"/> with setter methods
@@ -193,14 +193,13 @@ public abstract class TargetedAbility<T, TSingleTargetState> : Ability<T>
 		where TBuilder : AbstractBuilder<TBuilder, TAbility>
 		where TAbility : TargetedAbility<T, TSingleTargetState>, new()
 	{
-
 		protected Target? _target;
 		protected Func<T, string> GetTargetingHintText;
 
 		public TBuilder WithGetTargetingHintText(Func<T, string> getTargetingHintText)
 		{
 			GetTargetingHintText = getTargetingHintText;
-			Obj.GetTargetingHintText = getTargetingHintText;
+			Obj._getTargetingHintText = getTargetingHintText;
 			return (TBuilder)this;
 		}
 
@@ -282,7 +281,7 @@ public abstract class TargetedAbility<T, TSingleTargetState> : Ability<T>
 		/// </summary>
 		public override TAbility Build()
 		{
-			Obj.GetTargetingHintText = GetTargetingHintText ?? Obj.DefaultTargetingHintText;
+			Obj._getTargetingHintText = GetTargetingHintText ?? Obj.DefaultTargetingHintText;
 			return base.Build();
 		}
 	}
@@ -318,7 +317,7 @@ public abstract class TargetedAbility<T, TSingleTargetState> : Ability<T>
 
 		Conditions = conditions ?? [];
 		CustomGetTargets = customGetTargets;
-		GetTargetingHintText = getTargetingHintText ?? DefaultTargetingHintText;
+		_getTargetingHintText = getTargetingHintText ?? DefaultTargetingHintText;
 	}
 
 	protected override void InitializeState(T abilityState)
@@ -525,7 +524,7 @@ public abstract class TargetedAbility<T, TSingleTargetState> : Ability<T>
 				bool autoSelectIfOne = Mandatory || (customTargets != null && customTargets.Count == 1) || (TargetHex != null && AOEPattern == null);
 				TargetSelectionPrompt.Answer targetAnswer = await PromptManager.Prompt(
 					new TargetSelectionPrompt(getValidTargets, autoSelectIfOne, Mandatory, duringTargetedAbilityEffectCollection,
-						() => GetTargetingHintText(abilityState)), abilityState.Authority);
+						() => _getTargetingHintText(abilityState)), abilityState.Authority);
 
 				if(targetAnswer.Skipped)
 				{
@@ -541,7 +540,7 @@ public abstract class TargetedAbility<T, TSingleTargetState> : Ability<T>
 				Figure focus = await abilityState.ActionState.GetFocus();
 				MonsterTargetSelectionPrompt.Answer targetAnswer = await PromptManager.Prompt(
 					new MonsterTargetSelectionPrompt(getValidTargets, true, focus, duringTargetedAbilityEffectCollection,
-						() => GetTargetingHintText(abilityState)), abilityState.Authority);
+						() => _getTargetingHintText(abilityState)), abilityState.Authority);
 
 				if(targetAnswer.Skipped)
 				{

--- a/Game/Scripts/Models/Abilities/UseSlotAbility.cs
+++ b/Game/Scripts/Models/Abilities/UseSlotAbility.cs
@@ -2,6 +2,9 @@
 using System.Collections.Generic;
 using Fractural.Tasks;
 
+/// <summary>
+/// An <see cref="ActiveAbility{T}"/> that has a number of uses before it is discarded/lost.
+/// </summary>
 public class UseSlotAbility : ActiveAbility<UseSlotAbility.State>
 {
 	public class State : ActiveAbilityState
@@ -39,19 +42,95 @@ public class UseSlotAbility : ActiveAbility<UseSlotAbility.State>
 		}
 	}
 
-	public List<UseSlot> UseSlots { get; }
-	public Func<State, GDTask> OnActivate { get; }
-	public Func<State, GDTask> OnDeactivate { get; }
+	public List<UseSlot> UseSlots { get; protected set; } = [];
+	// TODO varadski 21.08.2025: seen in OtherActiveAbility as well; move to ActiveAbility.cs?
+	public Func<State, GDTask> OnActivate { get; protected set; }
+	public Func<State, GDTask> OnDeactivate { get; protected set; }
+
+	/// <summary>
+	/// A builder extending <see cref="ActiveAbility{T}.AbstractBuilder{TBuilder, TAbility}"/> with setter methods
+	/// for values defined in UseSlotAbility. Enables inheritors of UseSlotAbility to further extend the builder.
+	/// </summary>
+	/// <typeparam name="TBuilder"></typeparam> Any builder extending this AbstractBuilder.
+	/// <typeparam name="TAbility"></typeparam> Any ability extending UseSlotAbility.
+	public new class AbstractBuilder<TBuilder, TAbility> : ActiveAbility<State>.AbstractBuilder<TBuilder, TAbility>,
+		AbstractBuilder<TBuilder, TAbility>.IOnActivateStep,
+		AbstractBuilder<TBuilder, TAbility>.IOnDeactivateStep,
+		AbstractBuilder<TBuilder, TAbility>.IUseSlotsStep
+		where TBuilder : AbstractBuilder<TBuilder, TAbility>
+		where TAbility : UseSlotAbility, new()
+	{
+		public interface IOnActivateStep
+		{
+			IOnDeactivateStep WithOnActivate(Func<State, GDTask> onActivate);
+		}
+
+		public interface IOnDeactivateStep
+		{
+			IUseSlotsStep WithOnDeactivate(Func<State, GDTask> onDeactivate);
+		}
+
+		public interface IUseSlotsStep
+		{
+			TBuilder WithUseSlot(UseSlot useSlot);
+			TBuilder WithUseSlots(List<UseSlot> useSlots);
+		}
+
+		public TBuilder WithUseSlot(UseSlot useSlot)
+		{
+			Obj.UseSlots.Add(useSlot);
+			return (TBuilder)this;
+		}
+
+		public TBuilder WithUseSlots(List<UseSlot> useSlots)
+		{
+			Obj.UseSlots = useSlots;
+			return (TBuilder)this;
+		}
+
+		public IOnDeactivateStep WithOnActivate(Func<State, GDTask> onActivate)
+		{
+			Obj.OnActivate = onActivate;
+			return (TBuilder)this;
+		}
+
+		public IUseSlotsStep WithOnDeactivate(Func<State, GDTask> onDeactivate)
+		{
+			Obj.OnDeactivate = onDeactivate;
+			return (TBuilder)this;
+		}
+	}
+
+	/// <summary>
+	/// A concrete implementation of the AbstractBuilder. Required to actually use the builder,
+	/// as abstract builders cannot be instantiated.
+	/// </summary>
+	public class UseSlotBuilder : AbstractBuilder<UseSlotBuilder, UseSlotAbility>
+	{
+		internal UseSlotBuilder() { }
+	}
+
+	/// <summary>
+	/// A convenience method that returns an instance of UseSlotBuilder.
+	/// </summary>
+	/// <returns></returns>
+	public static AbstractBuilder<UseSlotBuilder, UseSlotAbility>.IOnActivateStep Builder()
+	{
+		return new UseSlotBuilder();
+	}
+
+	public UseSlotAbility() { }
 
 	public UseSlotAbility(List<UseSlot> useSlots,
 		Func<State, GDTask> onActivate, Func<State, GDTask> onDeactivate,
 		Func<State, GDTask> onAbilityStarted = null, Func<State, GDTask> onAbilityEnded = null, Func<State, GDTask> onAbilityEndedPerformed = null,
 		ConditionalAbilityCheckDelegate conditionalAbilityCheck = null,
 		Func<State, string> getHintText = null,
-		List<ScenarioEvents.AbilityStarted.Subscription> abilityStartedSubscriptions = null,
-		List<ScenarioEvents.AbilityEnded.Subscription> abilityEndedSubscriptions = null,
+		List<ScenarioEvent<ScenarioEvents.AbilityStarted.Parameters>.Subscription> abilityStartedSubscriptions = null,
+		List<ScenarioEvent<ScenarioEvents.AbilityEnded.Parameters>.Subscription> abilityEndedSubscriptions = null,
 		List<ScenarioEvent<ScenarioEvents.AbilityPerformed.Parameters>.Subscription> abilityPerformedSubscriptions = null)
-		: base(onAbilityStarted, onAbilityEnded, onAbilityEndedPerformed, conditionalAbilityCheck, getHintText, abilityStartedSubscriptions, abilityEndedSubscriptions, abilityPerformedSubscriptions)
+		: base(onAbilityStarted, onAbilityEnded, onAbilityEndedPerformed, conditionalAbilityCheck, getHintText, abilityStartedSubscriptions,
+			abilityEndedSubscriptions, abilityPerformedSubscriptions)
 	{
 		UseSlots = useSlots;
 		OnActivate = onActivate;

--- a/Game/Scripts/Models/Abilities/UseSlotAbility.cs
+++ b/Game/Scripts/Models/Abilities/UseSlotAbility.cs
@@ -42,10 +42,9 @@ public class UseSlotAbility : ActiveAbility<UseSlotAbility.State>
 		}
 	}
 
-	public List<UseSlot> UseSlots { get; protected set; } = [];
-	// TODO varadski 21.08.2025: seen in OtherActiveAbility as well; move to ActiveAbility.cs?
-	public Func<State, GDTask> OnActivate { get; protected set; }
-	public Func<State, GDTask> OnDeactivate { get; protected set; }
+	public List<UseSlot> UseSlots { get; private set; } = [];
+	public Func<State, GDTask> OnActivate { get; private set; }
+	public Func<State, GDTask> OnDeactivate { get; private set; }
 
 	/// <summary>
 	/// A builder extending <see cref="ActiveAbility{T}.AbstractBuilder{TBuilder, TAbility}"/> with setter methods
@@ -114,7 +113,7 @@ public class UseSlotAbility : ActiveAbility<UseSlotAbility.State>
 	/// A convenience method that returns an instance of UseSlotBuilder.
 	/// </summary>
 	/// <returns></returns>
-	public static AbstractBuilder<UseSlotBuilder, UseSlotAbility>.IOnActivateStep Builder()
+	public static UseSlotBuilder.IOnActivateStep Builder()
 	{
 		return new UseSlotBuilder();
 	}


### PR DESCRIPTION
As per the first step of [`TSC-003`](https://github.com/HoogeboomBas/TheCrimsonScales/issues/10), I've added all of the builders for `Ability.cs`. I have made three commits to encourage reviewing the files in that order, as they have been logically split:

- `Ability.cs` and all inheritors that do not have inheritors of their own.
- `ActiveAbility.cs` and all of its inheritors.
- `TargetedAbility.cs` and all of its inheritors.

P.S. There are some TODOs in the code; these are open questions for possible changes that will not be covered by this issue, as the scope is large enough as it is.