### PR TITLE
Check for elements that are already infusing before prompt

### DIFF
--- a/Game/Content/Items/GHDesigns/075_CircletOfElements.cs
+++ b/Game/Content/Items/GHDesigns/075_CircletOfElements.cs
@@ -1,3 +1,5 @@
+using System.Linq;
+
 public class CircletOfElements : GHDesignsItem
 {
 	public override string Name => "Circlet of Elements";
@@ -17,6 +19,11 @@ public class CircletOfElements : GHDesignsItem
 			canApply: character =>
 			{
 				if(character != Owner)
+				{
+					return false;
+				}
+
+				if(GameController.Instance.ElementManager.GetAvailableForInfusion().Count() == 0) 
 				{
 					return false;
 				}

--- a/Game/Content/Items/Prosperity2/020_MinorManaPotion.cs
+++ b/Game/Content/Items/Prosperity2/020_MinorManaPotion.cs
@@ -1,3 +1,5 @@
+using System.Linq;
+
 public class MinorManaPotion : Prosperity2Item
 {
 	public override string Name => "Minor Mana Potion";
@@ -14,7 +16,7 @@ public class MinorManaPotion : Prosperity2Item
 		base.Subscribe();
 
 		SubscribeDuringTurn(
-			canApply: character => character == Owner,
+			canApply: character => character == Owner && GameController.Instance.ElementManager.GetAvailableForInfusion().Count() > 0,
 			apply: async character =>
 			{
 				await Use(async user =>

--- a/Game/Scripts/Scenario/Abilities/AbilityCmd.cs
+++ b/Game/Scripts/Scenario/Abilities/AbilityCmd.cs
@@ -458,7 +458,7 @@ public static class AbilityCmd
 	public static GDTask InfuseElement(Figure authority, IReadOnlyCollection<Element> possibleElements)
 	{
 		List<ScenarioEvents.GenericChoice.Subscription> subscriptions = new List<ScenarioEvent<ScenarioEvents.GenericChoice.Parameters>.Subscription>();
-		foreach(Element possibleElement in possibleElements)
+		foreach(Element possibleElement in possibleElements.Except(GameController.Instance.ElementManager.GetInfusing()))
 		{
 			subscriptions.Add(ScenarioEvent<ScenarioEvents.GenericChoice.Parameters>.Subscription.New(
 				applyFunction: async parameters =>

--- a/Game/Scripts/Scenario/Abilities/AbilityCmd.cs
+++ b/Game/Scripts/Scenario/Abilities/AbilityCmd.cs
@@ -452,13 +452,13 @@ public static class AbilityCmd
 
 	public static GDTask InfuseWildElement(Figure authority)
 	{
-		return InfuseElement(authority, Elements.All);
+		return InfuseElement(authority, GameController.Instance.ElementManager.GetAvailableForInfusion());
 	}
 
-	public static GDTask InfuseElement(Figure authority, IReadOnlyCollection<Element> possibleElements)
+	public static GDTask InfuseElement(Figure authority, IEnumerable<Element> possibleElements)
 	{
 		List<ScenarioEvents.GenericChoice.Subscription> subscriptions = new List<ScenarioEvent<ScenarioEvents.GenericChoice.Parameters>.Subscription>();
-		foreach(Element possibleElement in possibleElements.Except(GameController.Instance.ElementManager.GetInfusing()))
+		foreach(Element possibleElement in possibleElements)
 		{
 			subscriptions.Add(ScenarioEvent<ScenarioEvents.GenericChoice.Parameters>.Subscription.New(
 				applyFunction: async parameters =>

--- a/Game/Scripts/Scenario/Elements/ElementManager.cs
+++ b/Game/Scripts/Scenario/Elements/ElementManager.cs
@@ -10,6 +10,11 @@ public class ElementManager
 		return _states[(int)element];
 	}
 
+	public IReadOnlyList<Element> GetInfusing()
+	{
+		return _infusing.AsReadOnly();
+	}
+
 	public void StartInfuse(Element element)
 	{
 		_infusing.AddIfNew(element);

--- a/Game/Scripts/Scenario/Elements/ElementManager.cs
+++ b/Game/Scripts/Scenario/Elements/ElementManager.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 
 public class ElementManager
 {
@@ -10,9 +11,9 @@ public class ElementManager
 		return _states[(int)element];
 	}
 
-	public IReadOnlyList<Element> GetInfusing()
+	public IEnumerable<Element> GetAvailableForInfusion()
 	{
-		return _infusing.AsReadOnly();
+		return Elements.All.Except(_infusing);
 	}
 
 	public void StartInfuse(Element element)


### PR DESCRIPTION
If an element is already "infusing", don't let choose it a second time ( with mana potion for example )
And check if any elements are not currently infusing before letting waste mana potion and circlet of elements. 


Also tested a case where no elements are available due to this change, then the infusion is simply skipped.




Let me know if you prefer another solution.