### PR TITLE
Implement empowering talisman

### DIFF
--- a/Game/Content/Items/Prosperity2/017_EmpoweringTalisman.cs
+++ b/Game/Content/Items/Prosperity2/017_EmpoweringTalisman.cs
@@ -1,3 +1,5 @@
+using System.Linq;
+
 public class EmpoweringTalisman : Prosperity2Item
 {
 	public override string Name => "Empowering Talisman";
@@ -8,4 +10,22 @@ public class EmpoweringTalisman : Prosperity2Item
 	public override ItemUseType ItemUseType => ItemUseType.Consume;
 
 	protected override int AtlasIndex => 4;
+
+	protected override void Subscribe()
+	{
+		base.Subscribe();
+
+		SubscribeDuringTurn(
+			canApply: character => character == Owner && 
+			character.Items.Any(item => item.ItemState == ItemState.Consumed && item.ItemType == ItemType.Small),
+			apply: async character =>
+			{
+				await Use(async user =>
+				{
+					ItemModel item = await AbilityCmd.SelectItem(character, ItemState.Consumed, ItemType.Small, "Select an item to refresh");
+					await AbilityCmd.RefreshItem(item);
+				});
+			}
+		);
+	}
 }

--- a/Game/Content/Scenarios/Scenario007.cs
+++ b/Game/Content/Scenarios/Scenario007.cs
@@ -294,7 +294,7 @@ public class Scenario007 : ScenarioModel
 			{
 				if(character.Items.Any(item => item.ItemState == ItemState.Spent))
 				{
-					ItemModel item = await AbilityCmd.SelectItem(character, ItemState.Spent, "Select an item to refresh");
+					ItemModel item = await AbilityCmd.SelectItem(character, ItemState.Spent, hintText: "Select an item to refresh");
 					await AbilityCmd.RefreshItem(item);
 				}
 

--- a/Game/Scripts/Scenario/Abilities/AbilityCmd.cs
+++ b/Game/Scripts/Scenario/Abilities/AbilityCmd.cs
@@ -564,7 +564,7 @@ public static class AbilityCmd
 		await GDTask.CompletedTask;
 	}
 
-	public static async GDTask<ItemModel> SelectItem(Character characterAndAuthority, ItemState requiredItemState, string hintText = "Select an item")
+	public static async GDTask<ItemModel> SelectItem(Character characterAndAuthority, ItemState requiredItemState, ItemType? requiredItemType = null, string hintText = "Select an item")
 	{
 		List<ScenarioEvents.GenericChoice.Subscription> subscriptions = new List<ScenarioEvent<ScenarioEvents.GenericChoice.Parameters>.Subscription>();
 
@@ -573,6 +573,11 @@ public static class AbilityCmd
 		foreach(ItemModel item in characterAndAuthority.Items)
 		{
 			if(item.ItemState != requiredItemState)
+			{
+				continue;
+			}
+
+			if(requiredItemType != null && item.ItemType != requiredItemType)
 			{
 				continue;
 			}


### PR DESCRIPTION
Major changes:

In order for the talisman to function properly, Items are no longer Subscribing and Unsubscribing when Restored and Consumed/Spent and are always Subscribed during the scenario.
Instead, now this.ItemState == ItemState.Available check is added to canApply subscriptions called through ItemModel.

I don't like this because if an item implementation calls ScenarioEvent.Subscribe directly, there will be no check for if the item is exhausted or spent. Please help me think of something to prevent that.

 Default of canApplyMultipleTimesDuringAbility is changed to true. Was there a specific reason why it was false by default? I don't see why item couldn't be used multiple times during an ability, for example Hide Armor during 2 attacks in one ability.

Minor changes:

Add ItemType? nullable argument to SelectItem to support chosing only small items for the talisman usage.