### PR TITLE
Fix the fix, self abilities working again

### DIFF
--- a/Game/Scripts/Models/Abilities/TargetedAbility.cs
+++ b/Game/Scripts/Models/Abilities/TargetedAbility.cs
@@ -420,7 +420,8 @@ public abstract class TargetedAbility<T, TSingleTargetState> : Ability<T>
 					remove = true;
 				}
 
-				if(!Target.HasFlag(Target.Allies) && !Target.HasFlag(Target.Self) && abilityState.Authority == figure)
+				if(Target.HasFlag(Target.Enemies) && abilityState.Authority == figure && 
+					abilityState.Authority.EnemiesWith(abilityState.Performer))
 				{
 					remove = true;
 				}


### PR DESCRIPTION
The previous line reverted to what it was and made another one.

I hope it works as intended and is clear now.
If a figure is an authority and the ability is to target enemies, and the authority is an enemy of the performer, don't count it as one.