### PR TITLE
Create a monster group and other fixes

### DIFF
--- a/Game/Content/Classes/Hierophant/Cards/02_ImpetuousInquisition.cs
+++ b/Game/Content/Classes/Hierophant/Cards/02_ImpetuousInquisition.cs
@@ -80,16 +80,7 @@ public class ImpetuousInquisition : HierophantCardModel<ImpetuousInquisition.Car
 						RetaliateAbility.Builder().WithRetaliateValue(1).Build()
 					]
 				)
-				.WithCustomGetTargets((state, list) =>
-				{
-					foreach(Figure figure in GameController.Instance.Map.Figures)
-					{
-						if(state.Performer.AlliedWith(figure))
-						{
-							list.Add(figure);
-						}
-					}
-				})
+				.WithTarget(Target.Allies | Target.TargetAll)
 				.WithOnAbilityEndedPerformed(async state =>
 				{
 					await AbilityCmd.GainXP(state.Performer, 1);

--- a/Game/Content/Classes/Hierophant/Cards/05_InnerReflection.cs
+++ b/Game/Content/Classes/Hierophant/Cards/05_InnerReflection.cs
@@ -38,7 +38,7 @@ public class InnerReflection : HierophantCardModel<InnerReflection.CardTop, Inne
 						{
 							foreach(Figure otherFigure in RangeHelper.GetFiguresInRange(state.Performer.Hex, 2))
 							{
-								if(state.Performer.AlliedWith(otherFigure))
+								if(state.Performer.AlliedWith(otherFigure) && otherFigure is Character)
 								{
 									list.Add(otherFigure);
 								}

--- a/Game/Content/Scenarios/Scenario004.cs
+++ b/Game/Content/Scenarios/Scenario004.cs
@@ -179,6 +179,7 @@ public class Scenario004 : ScenarioModel
 			ScenarioCheckEvents.CanBeTargetedCheckEvent.Subscribe(monster, this,
 				parameters =>
 					parameters.PotentialTarget == monster &&
+					parameters.Performer is not Character &&
 					parameters.PotentialAbilityState != null &&
 					parameters.PotentialAbilityState is not HealAbility.State,
 				parameters =>

--- a/Game/Content/Scenarios/Scenario005.tscn
+++ b/Game/Content/Scenarios/Scenario005.tscn
@@ -253,7 +253,7 @@ MonsterType4Characters = 1
 
 [node name="MonsterSpawner6" parent="Map/Rooms/Room2" index="33" instance=ExtResource("9_vx3hm")]
 position = Vector2(1418.55, -1323)
-MonsterModelId = "MONSTER_MODEL.GELATINOUS_GIANT"
+MonsterModelId = "OOZE.GELATINOUS_GIANT"
 MonsterType2Characters = 2
 MonsterType3Characters = 2
 MonsterType4Characters = 2

--- a/Game/Scripts/Models/Abilities/HealAbility.cs
+++ b/Game/Scripts/Models/Abilities/HealAbility.cs
@@ -241,7 +241,7 @@ public class HealAbility : TargetedAbility<HealAbility.State, HealAbility.HealAb
 	{
 		base.GetValidTargets(abilityState, figures, targetsOutOfAOE);
 
-		if(abilityState.Authority is not Character)
+		if(abilityState.Authority is not Character && figures.Count != 0)
 		{
 			int mostHealthLost = figures.Select(figure => figure.MaxHealth - figure.Health).Max();
 			figures.RemoveAll(figure => figure.MaxHealth - figure.Health < mostHealthLost);

--- a/Game/Scripts/Scenario/Map.cs
+++ b/Game/Scripts/Scenario/Map.cs
@@ -114,7 +114,12 @@ public partial class Map : Node2D
 	public async GDTask<Monster> CreateMonster(MonsterModel monsterModel, MonsterType monsterType, Vector2I coords, bool summon,
 		int? monsterLevel = null, Alignment alignment = Alignment.Enemies, Alignment enemies = Alignment.Characters)
 	{
-		MonsterGroup monsterGroup = MonsterGroups.First(group => group.MonsterModel == monsterModel);
+		MonsterGroup monsterGroup = MonsterGroups.Find(group => group.MonsterModel == monsterModel);
+		if(monsterGroup == null)
+		{
+			GameController.Instance.Map.AddMonsterGroup(monsterModel);
+			monsterGroup = MonsterGroups.First(group => group.MonsterModel == monsterModel);
+		}
 
 		if(monsterType != MonsterType.None && monsterGroup.TryGetAvailableStandeeNumber(out int standeeNumber))
 		{


### PR DESCRIPTION
Fixes a bug with monster group not existing for summoned monsters/allies.
Fixes Inner Reflection being able to give coins to non-characters.
Fixes Impetious Inquisition giving retaliate only to one ally instead of all.
Fixes a crash when monster heal ability has no targets.
In scenario 4 fix enemies being able to heal infected warriors.
Fix crash in scenario 5.