### PR TITLE
Bug fixes

### DIFF
--- a/Game/Content/Classes/Hollowpact/AMDCards/HollowpactAMDCards.cs
+++ b/Game/Content/Classes/Hollowpact/AMDCards/HollowpactAMDCards.cs
@@ -27,7 +27,7 @@ public class HollowpactAMDCards
 
 		protected override int AtlasIndex => 3;
 
-		public override int? GetValue(AttackAbility.State attackAbilityState) => +0;
+		public override int? GetValue(AttackAbility.State attackAbilityState) => +3;
 		public override List<Ability> GetAbilities(AttackAbility.State attackAbilityState) =>
 		[
 			ConditionAbility.Builder().WithConditions(Conditions.Regenerate).WithTarget(Target.Self).Build()
@@ -47,7 +47,7 @@ public class HollowpactAMDCards
 		public override string ToString(RichTextParameters richTextParameters) =>
 			GetBasicString(richTextParameters, +1,
 				extraText: $"Create a void pit in an empty hex within {Icons.Inline(Icons.Range, richTextParameters)}2");
-	
+
 		protected override int AtlasIndex => 9;
 
 		public override int? GetValue(AttackAbility.State attackAbilityState) => +1;
@@ -142,7 +142,7 @@ public class HollowpactAMDCards
 		public override int? GetValue(AttackAbility.State attackAbilityState) => -2;
 		public override List<CardElementInfusion> ElementInfusions => [CardElementInfusion.Infuse(Element.Earth)];
 	}
-	
+
 	public class MinusTwoStun : HollowpactAMDCardModel
 	{
 		protected override int AtlasIndex => 22;

--- a/Game/Content/Classes/Hollowpact/Cards/17_MajesticMalevolence.cs
+++ b/Game/Content/Classes/Hollowpact/Cards/17_MajesticMalevolence.cs
@@ -35,6 +35,16 @@ public class MajesticMalevolence : HollowpactLevelUpCardModel<MajesticMalevolenc
 						effectInfoViewParameters: new TextEffectInfoView.Parameters(
 							"Perform the ability as if you were occupying a hex with a Void Pit"));
 
+					ScenarioEvents.ActionEndedEvent.Subscribe(state, this,
+						parameters => parameters.ActionState.Performer == state.Performer,
+						async parameters =>
+						{
+							ScenarioEvents.AbilityStartedEvent.Unsubscribe(state, this);
+							ScenarioEvents.ActionEndedEvent.Unsubscribe(state, this);
+
+							await GDTask.CompletedTask;
+						});
+
 					await GDTask.CompletedTask;
 				})
 				.WithOnDeactivate(async state =>

--- a/Game/Content/Classes/Hollowpact/Cards/17_MajesticMalevolence.cs
+++ b/Game/Content/Classes/Hollowpact/Cards/17_MajesticMalevolence.cs
@@ -26,6 +26,7 @@ public class MajesticMalevolence : HollowpactLevelUpCardModel<MajesticMalevolenc
 								await targetedAbilityState.SetPerformHex(hexes =>
 								{
 									hexes.AddRange(GameController.Instance.Map.GetChildrenOfType<VoidPit>()
+										.Where(voidpit => !voidpit.IsDestroyed)
 										.Select(voidPit => voidPit.Hex));
 								});
 							}

--- a/Game/Content/Classes/Hollowpact/Cards/21_StalkingQuarry.cs
+++ b/Game/Content/Classes/Hollowpact/Cards/21_StalkingQuarry.cs
@@ -21,7 +21,7 @@ public class StalkingQuarry : HollowpactLevelUpCardModel<StalkingQuarry.CardTop,
 					return teleportTargetHex.Neighbours
 						.Any(potentialEnemyHex =>
 							potentialEnemyHex.GetFigures().Any(figure => figure.EnemiesWith(state.Performer))
-							&& !potentialEnemyHex.Neighbours.Any(otherFigureHex => otherFigureHex.HasHexObjectOfType<Figure>()));
+							&& !potentialEnemyHex.Neighbours.Any(otherFigureHex => otherFigureHex.GetHexObjectsOfType<Figure>().Any(figure => figure != state.Performer)));
 				})
 				.Build()),
 

--- a/Game/Content/Classes/Hollowpact/Cards/22_Implosion.cs
+++ b/Game/Content/Classes/Hollowpact/Cards/22_Implosion.cs
@@ -31,6 +31,7 @@ public class Implosion : HollowpactLevelUpCardModel<Implosion.CardTop, Implosion
 					Hex hex = await AbilityCmd.SelectHex(state, hexes =>
 					{
 						hexes.AddRange(GameController.Instance.Map.GetChildrenOfType<VoidPit>()
+							.Where(voidpit => !voidpit.IsDestroyed)
 							.Select(voidPit => voidPit.Hex));
 					}, hintText: $"Select a hex with a Void Pit.");
 

--- a/Game/Content/Classes/Hollowpact/Cards/25_GatewayToTheAbyss.cs
+++ b/Game/Content/Classes/Hollowpact/Cards/25_GatewayToTheAbyss.cs
@@ -30,6 +30,7 @@ public class GatewayToTheAbyss : HollowpactLevelUpCardModel<GatewayToTheAbyss.Ca
 				.WithCustomGetTargets((state, figures) =>
 				{
 					figures.AddRange(GameController.Instance.Map.GetChildrenOfType<VoidPit>()
+						.Where(voidpit => !voidpit.IsDestroyed)
 						.SelectMany(voidPit => voidPit.Hex.Neighbours.SelectMany(hex => hex.GetFigures()))
 						.Where(figure => figure.EnemiesWith(state.Performer))
 						.Distinct());
@@ -39,6 +40,7 @@ public class GatewayToTheAbyss : HollowpactLevelUpCardModel<GatewayToTheAbyss.Ca
 					await GainXP(state);
 
 					IEnumerable<Figure> alliedFigures = GameController.Instance.Map.GetChildrenOfType<VoidPit>()
+						.Where(voidpit => !voidpit.IsDestroyed)
 						.SelectMany(voidPit => voidPit.Hex.Neighbours.SelectMany(hex => hex.GetFigures()))
 						.Where(figure => figure.AlliedWith(state.Performer))
 						.Distinct();

--- a/Game/Content/Classes/Starslinger/AMDCards/StarslingerAMDCards.cs
+++ b/Game/Content/Classes/Starslinger/AMDCards/StarslingerAMDCards.cs
@@ -72,7 +72,7 @@ public class StarslingerAMDCards
 		];
 	}
 
-	public class PlusOneIfYouAreUndamagedPlusThreeInstead : BombardAMDCardModel
+	public class PlusOneIfYouAreUndamagedPlusThreeInstead : StarslingerAMDCardModel
 	{
 		public override string ToString(RichTextParameters richTextParameters) =>
 			GetBasicString(richTextParameters, +1,

--- a/Game/Content/Scenarios/Scenario011.tscn
+++ b/Game/Content/Scenarios/Scenario011.tscn
@@ -31,6 +31,7 @@ _hideDuringPlay = true
 
 [node name="DarkPit2H" parent="Map/Rooms/Room" index="3" unique_id=1977939900 instance=ExtResource("6_hwybe")]
 position = Vector2(545.59595, -189)
+CannotBeDestroyed = true
 
 [node name="B2a" parent="Map/Rooms/Room" index="4" unique_id=174833049 instance=ExtResource("7_jtiwx")]
 position = Vector2(1091.1919, 0)
@@ -48,6 +49,7 @@ _hideDuringPlay = true
 [node name="DarkPit2H2" parent="Map/Rooms/Room" index="7" unique_id=232390639 instance=ExtResource("6_hwybe")]
 position = Vector2(1309.4303, 378)
 rotation = 2.0943952
+CannotBeDestroyed = true
 
 [node name="B3a" parent="Map/Rooms/Room" index="8" unique_id=2127703404 instance=ExtResource("8_5tlut")]
 position = Vector2(0, 1134)
@@ -65,6 +67,7 @@ _hideDuringPlay = true
 [node name="DarkPit2H3" parent="Map/Rooms/Room" index="11" unique_id=99891417 instance=ExtResource("6_hwybe")]
 position = Vector2(0, 378)
 rotation = 1.0471976
+CannotBeDestroyed = true
 
 [node name="B4a" parent="Map/Rooms/Room" index="12" unique_id=1959967987 instance=ExtResource("9_2lgbt")]
 position = Vector2(1091.1919, 1134)
@@ -81,3 +84,4 @@ _hideDuringPlay = true
 
 [node name="DarkPit2H4" parent="Map/Rooms/Room" index="15" unique_id=1128881103 instance=ExtResource("6_hwybe")]
 position = Vector2(545.59595, 945)
+CannotBeDestroyed = true

--- a/Game/Content/Scenarios/Scenario039.cs
+++ b/Game/Content/Scenarios/Scenario039.cs
@@ -305,6 +305,7 @@ public class Scenario039 : ScenarioModel
 						{
 							Hex hex = await AbilityCmd.SelectHex(GameController.Instance.CharacterManager.FirstAlive(), list =>
 									list.AddRange(GameController.Instance.Map.GetChildrenOfType<Boulder1HObstacle>()
+										.Where(boulder => !boulder.IsDestroyed)
 										.Select(obstacle => obstacle.Hex)), true,
 								"Select a boulder to destroy");
 							if(hex != null)

--- a/Game/Scripts/Models/Abilities/AttackAbility.cs
+++ b/Game/Scripts/Models/Abilities/AttackAbility.cs
@@ -296,7 +296,8 @@ public class AttackAbility : TargetedAbility<AttackAbility.State, SingleTargetSt
 
 	protected override async GDTask AfterTargetConfirmedBeforeConditionsApplied(State abilityState, Figure target)
 	{
-		if(CheckRangeDisadvantage(abilityState.Performer.Hexes, target.Hexes, abilityState.SingleTargetRangeType))
+		Hex[] performHexes = abilityState.AbilityPerformHex != null ? [abilityState.AbilityPerformHex] : abilityState.Performer.Hexes;
+		if(CheckRangeDisadvantage(performHexes, target.Hexes, abilityState.SingleTargetRangeType))
 		{
 			abilityState.SingleTargetSetHasDisadvantage();
 		}

--- a/Game/Scripts/Models/Abilities/HealAbility.cs
+++ b/Game/Scripts/Models/Abilities/HealAbility.cs
@@ -187,7 +187,7 @@ public class HealAbility : TargetedAbility<HealAbility.State, HealAbility.HealAb
 			await ScenarioEvents.HealBlockTimeEvent.CreatePrompt(
 				new ScenarioEvents.HealBlockTime.Parameters(abilityState), abilityState);
 
-		if(!blockedAbilityStateParameters.IsBlocked)
+		if(!blockedAbilityStateParameters.IsBlocked && target.Health < target.MaxHealth)
 		{
 			int newHealth = Mathf.Min(target.Health + abilityState.SingleTargetHealValue, target.MaxHealth);
 
@@ -243,7 +243,7 @@ public class HealAbility : TargetedAbility<HealAbility.State, HealAbility.HealAb
 
 		if(abilityState.Authority is not Character && figures.Count != 0)
 		{
-			int mostHealthLost = figures.Select(figure => figure.MaxHealth - figure.Health).Max();
+			int mostHealthLost = figures.Max(figure => figure.MaxHealth - figure.Health);
 			figures.RemoveAll(figure => figure.MaxHealth - figure.Health < mostHealthLost);
 		}
 	}

--- a/Game/Scripts/Models/Abilities/TargetedAbility.cs
+++ b/Game/Scripts/Models/Abilities/TargetedAbility.cs
@@ -761,7 +761,7 @@ public abstract class TargetedAbility<T, TSingleTargetState> : Ability<T>, ITarg
 		{
 			target.ZIndex = 100;
 
-			for(int i = 0; i < path.Count; i++)
+			for(int i = 0; i < path.Count && !target.IsDestroyed; i++)
 			{
 				Vector2I coords = path[i];
 				Hex hex = GameController.Instance.Map.GetHex(coords);


### PR DESCRIPTION
1. Forbid to destroy obstacles scenario 11.
2. Fix copy-paste error in starslinger AMD.
3. Fix AMD attack value on hollowpact.
4. Add a check for destroyed obstacles when targeting then with GetChildrenOfType.
5. Fix Majestic malevolence working after action ended.
6. Fix stalking quarry counting yourself as a figure.
7. Fix when healing over max hp reverting to max.
8. Fix forced movement not checking for death same as movement.
9. Fix disadvantage check not taking into account perform hex.