### PR TITLE
Improve teleport ability

### DIFF
--- a/Game/Content/Classes/Hollowpact/Cards/09_ReachingDarkness.cs
+++ b/Game/Content/Classes/Hollowpact/Cards/09_ReachingDarkness.cs
@@ -39,7 +39,7 @@ public class ReachingDarkness : HollowpactCardModel<ReachingDarkness.CardTop, Re
 				{
 					foreach(Hex targetedHex in state.ActionState.GetAbilityState<SufferDamageAbility.State>(0).TargetedHexes)
 					{
-						hexes.AddRange(RangeHelper.GetHexesInRange(origin: targetedHex, range: 1, includeOrigin: false).Where(hex => hex.IsEmpty()));
+						hexes.AddRange(RangeHelper.GetHexesInRange(origin: targetedHex, range: 1, includeOrigin: false));
 					}
 				})
 				.WithConditionalAbilityCheck(async state =>

--- a/Game/Content/Classes/Hollowpact/Cards/25_GatewayToTheAbyss.cs
+++ b/Game/Content/Classes/Hollowpact/Cards/25_GatewayToTheAbyss.cs
@@ -106,17 +106,16 @@ public class GatewayToTheAbyss : HollowpactLevelUpCardModel<GatewayToTheAbyss.Ca
 				.Build()),
 
 			new AbilityCardAbility(GrantAbility.Builder()
-				.WithAbilities(
+				.WithGetAbilities(grantState =>
 				[
 					TeleportAbility.Builder()
 						.WithCustomGetHexes((state, hexes) =>
 						{
-							hexes.AddRange(RangeHelper.GetHexesInRange(state.Performer.Hex, 5,
-									includeOrigin: false,
-									requiresLineOfSight: false,
-									requiresHexesRevealed: true,
-									allowDoors: true)
-								.Where(hex => hex.IsEmpty()));
+							hexes.AddRange(RangeHelper.GetHexesInRange(grantState.Performer.Hex, 5,
+								includeOrigin: false,
+								requiresLineOfSight: false,
+								requiresHexesRevealed: true,
+								allowDoors: true));
 						})
 						.Build()
 				])
@@ -136,17 +135,16 @@ public class GatewayToTheAbyss : HollowpactLevelUpCardModel<GatewayToTheAbyss.Ca
 				.Build()),
 
 			new AbilityCardAbility(ControlAbility.Builder()
-				.WithAbilities(
+				.WithGetAbilities(grantState =>
 				[
 					TeleportAbility.Builder()
 						.WithCustomGetHexes((state, hexes) =>
 						{
-							hexes.AddRange(RangeHelper.GetHexesInRange(state.Performer.Hex, 5,
-									includeOrigin: false,
-									requiresLineOfSight: false,
-									requiresHexesRevealed: true,
-									allowDoors: false)
-								.Where(hex => hex.IsEmpty()));
+							hexes.AddRange(RangeHelper.GetHexesInRange(grantState.Performer.Hex, 5,
+								includeOrigin: false,
+								requiresLineOfSight: false,
+								requiresHexesRevealed: true,
+								allowDoors: false));
 						})
 						.Build()
 				])

--- a/Game/Scripts/Models/Abilities/TeleportAbility.cs
+++ b/Game/Scripts/Models/Abilities/TeleportAbility.cs
@@ -97,6 +97,8 @@ public class TeleportAbility : Ability<TeleportAbility.State>
 	{
 		Figure performer = abilityState.Performer;
 
+		bool forcedMovement = abilityState.Performer.EnemiesWith(abilityState.Authority);
+
 		Hex destination = null;
 
 		if(abilityState.Authority is Character)
@@ -104,7 +106,7 @@ public class TeleportAbility : Ability<TeleportAbility.State>
 			// Character teleporting
 			TeleportPrompt.Answer teleportAnswer =
 				await PromptManager.Prompt(
-					new TeleportPrompt(abilityState, performer, null, customHexes: CustomGetHexes, filterHexes: FilterHexes,
+					new TeleportPrompt(abilityState, performer, null, customHexes: CustomGetHexes, filterHexes: FilterHexes, forcedMovement: forcedMovement,
 						getHintText: () => $"Select a destination for {Icons.HintText(Icons.Teleport)}" + (CustomGetHexes == null ? $"{abilityState.Distance}" : "")),
 					abilityState.Authority);
 
@@ -118,7 +120,7 @@ public class TeleportAbility : Ability<TeleportAbility.State>
 			// TODO: Not a real monster movement, focus and movement AI not included, works with custom hexes
 			MonsterTeleportPrompt.Answer monsterTeleportAnswer =
 				await PromptManager.Prompt(
-					new MonsterTeleportPrompt(abilityState, performer, null, customHexes: CustomGetHexes, filterHexes: FilterHexes,
+					new MonsterTeleportPrompt(abilityState, performer, null, customHexes: CustomGetHexes, filterHexes: FilterHexes, forcedMovement: forcedMovement,
 						getHintText: () => $"Select a destination for {Icons.HintText(Icons.Teleport)}" + (CustomGetHexes == null ? $"{abilityState.Distance}" : "")),
 					abilityState.Authority);
 
@@ -132,8 +134,6 @@ public class TeleportAbility : Ability<TeleportAbility.State>
 		{
 			return;
 		}
-
-		bool forcedMovement = abilityState.Performer.EnemiesWith(abilityState.Authority);
 
 		await AbilityCmd.Teleport(abilityState, performer, destination, forcedMovement);
 	}

--- a/Game/Scripts/Scenario/Prompts/MonsterTeleportPrompt.cs
+++ b/Game/Scripts/Scenario/Prompts/MonsterTeleportPrompt.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using Godot;
 
 public class MonsterTeleportPrompt(
-	TeleportAbility.State teleportAbilityState, Figure performer, EffectCollection effectCollection, Func<string> getHintText,
+	TeleportAbility.State teleportAbilityState, Figure performer, EffectCollection effectCollection, Func<string> getHintText, bool forcedMovement,
 	Action<TeleportAbility.State, List<Hex>> customHexes = null, Func<TeleportAbility.State, Hex, bool> filterHexes = null)
 	: Prompt<MonsterTeleportPrompt.Answer>(effectCollection, getHintText)
 {
@@ -26,19 +26,25 @@ public class MonsterTeleportPrompt(
 
 		_possibleHexes.Clear();
 
-		if(customHexes != null)
+		List<Hex> allHexesInRange = [];
+
+		if(customHexes == null)
 		{
-			customHexes(teleportAbilityState, _possibleHexes);
+			allHexesInRange.AddRange(GameController.Instance.Map.Hexes.Values
+				.Where(hex => hex.Revealed &&
+					Map.SimpleDistance(hex.Coords, performer.Hex.Coords) < teleportAbilityState.Distance));
 		}
 		else
 		{
-			foreach(Hex hex in GameController.Instance.Map.Hexes.Values.Where(hex => hex.Revealed))
+			customHexes(teleportAbilityState, allHexesInRange);
+		}
+
+		foreach(Hex hex in allHexesInRange)
+		{
+			if(MoveHelper.CanPass(teleportAbilityState, performer, hex, forcedMovement) &&
+				MoveHelper.CanStopAt(teleportAbilityState, performer, hex))
 			{
-				int distance = Map.SimpleDistance(hex.Coords, performer.Hex.Coords);
-				if(distance <= teleportAbilityState.Distance && MoveHelper.CanStopAt(teleportAbilityState, performer, hex))
-				{
-					_possibleHexes.Add(hex);
-				}
+				_possibleHexes.Add(hex);
 			}
 		}
 

--- a/Game/Scripts/Scenario/Prompts/TeleportPrompt.cs
+++ b/Game/Scripts/Scenario/Prompts/TeleportPrompt.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using Godot;
 
 public class TeleportPrompt(
-	TeleportAbility.State teleportAbilityState, Figure performer, EffectCollection effectCollection, Func<string> getHintText,
+	TeleportAbility.State teleportAbilityState, Figure performer, EffectCollection effectCollection, Func<string> getHintText, bool forcedMovement = false,
 	Action<TeleportAbility.State, List<Hex>> customHexes = null, Func<TeleportAbility.State, Hex, bool> filterHexes = null)
 	: Prompt<TeleportPrompt.Answer>(effectCollection, getHintText)
 {
@@ -26,19 +26,25 @@ public class TeleportPrompt(
 
 		_possibleHexes.Clear();
 
-		if(customHexes != null)
+		List<Hex> allHexesInRange = [];
+
+		if(customHexes == null)
 		{
-			customHexes(teleportAbilityState, _possibleHexes);
+			allHexesInRange.AddRange(GameController.Instance.Map.Hexes.Values
+				.Where(hex => hex.Revealed &&
+					Map.SimpleDistance(hex.Coords, performer.Hex.Coords) < teleportAbilityState.Distance));
 		}
 		else
 		{
-			foreach(Hex hex in GameController.Instance.Map.Hexes.Values.Where(hex => hex.Revealed))
+			customHexes(teleportAbilityState, allHexesInRange);
+		}
+
+		foreach(Hex hex in allHexesInRange)
+		{
+			if(MoveHelper.CanPass(teleportAbilityState, performer, hex, forcedMovement) &&
+				MoveHelper.CanStopAt(teleportAbilityState, performer, hex))
 			{
-				int distance = Map.SimpleDistance(hex.Coords, performer.Hex.Coords);
-				if(distance <= teleportAbilityState.Distance && MoveHelper.CanStopAt(teleportAbilityState, performer, hex))
-				{
-					_possibleHexes.Add(hex);
-				}
+				_possibleHexes.Add(hex);
 			}
 		}
 


### PR DESCRIPTION
Adds CanPass to CanStopAt to TeleportPrompt checks, similar to how both checks are performed on move hexes.
There is some duplicated checks between the both, so could be improved.

Makes it check the custom hexes too.