### PR TITLE
Luminary/Brightspark fixes

### DIFF
--- a/Game/Content/BattleGoals/10_Daredevil.cs
+++ b/Game/Content/BattleGoals/10_Daredevil.cs
@@ -17,10 +17,11 @@ public class Daredevil : TheCrimsonScalesBattleGoal
 	{
 		_failed = false;
 
-		ScenarioEvents.LostCardEvent.Subscribe(this,
+		ScenarioEvents.AbilityCardStateChangedEvent.Subscribe(this,
 			parameters =>
 				!battleGoal.ProgressFull &&
-				parameters.Character == character,
+				parameters.AbilityCard.Owner == character &&
+				(parameters.AbilityCard.CardState == CardState.Lost || parameters.AbilityCard.CardState == CardState.UnrecoverablyLost),
 			async parameters =>
 			{
 				battleGoal.AdjustProgress(1);

--- a/Game/Content/BattleGoals/42_Ritualist.cs
+++ b/Game/Content/BattleGoals/42_Ritualist.cs
@@ -13,7 +13,7 @@ public class Ritualist : TheCrimsonScalesBattleGoal
 				!battleGoal.ProgressFull &&
 				parameters.PotentialKiller == character &&
 				parameters.Figure.EnemiesWith(character) &&
-				Elements.All.Count(element => GameController.Instance.ElementManager.GetState(element) is ElementState.Waning or ElementState.Strong) > 3,
+				Elements.All.Count(element => GameController.Instance.ElementManager.GetState(element) is ElementState.Waning or ElementState.Strong) >= 3,
 			async parameters =>
 			{
 				battleGoal.AdjustProgress(1);

--- a/Game/Content/BattleGoals/55_Wallflower.cs
+++ b/Game/Content/BattleGoals/55_Wallflower.cs
@@ -16,8 +16,7 @@ public class Wallflower : TheCrimsonScalesBattleGoal
 			parameters =>
 				!battleGoal.ProgressFull &&
 				parameters.Figure == character &&
-				character.Hex.Neighbours.Count == 6 && // This should check for wall lines
-				!character.Hex.HasHexObjectOfType<Corridor>() &&
+				character.Hex.Neighbours.Count == 6 && // TODO: This should check for wall lines, this fails in case of a doorway
 				RangeHelper.GetHexesInRange(character.Hex, 1, false)
 					.All(hex => !hex.HasHexObjectOfType<Obstacle>() && !hex.HasHexObjectOfType<Objective>()),
 			async parameters =>

--- a/Game/Content/BattleGoals/55_Wallflower.cs
+++ b/Game/Content/BattleGoals/55_Wallflower.cs
@@ -17,6 +17,7 @@ public class Wallflower : TheCrimsonScalesBattleGoal
 				!battleGoal.ProgressFull &&
 				parameters.Figure == character &&
 				character.Hex.Neighbours.Count == 6 && // This should check for wall lines
+				!character.Hex.HasHexObjectOfType<Corridor>() &&
 				RangeHelper.GetHexesInRange(character.Hex, 1, false)
 					.All(hex => !hex.HasHexObjectOfType<Obstacle>() && !hex.HasHexObjectOfType<Objective>()),
 			async parameters =>

--- a/Game/Content/Classes/Brightspark/AMDCards/BrightsparkAMDCards.cs
+++ b/Game/Content/Classes/Brightspark/AMDCards/BrightsparkAMDCards.cs
@@ -86,7 +86,7 @@ public class BrightsparkAMDCards
 				extraText:
 				$"Grant one ally within {Icons.Inline(Icons.Range, richTextParameters)}2 {Icons.Inline(Icons.Shield, richTextParameters)}1");
 
-		protected override int AtlasIndex => 4;
+		protected override int AtlasIndex => 6;
 		public override int? GetValue(AttackAbility.State attackAbilityState) => +1;
 
 		public override List<Ability> GetAbilities(AttackAbility.State attackAbilityState) =>

--- a/Game/Content/Classes/Brightspark/BrightsparkPerks.cs
+++ b/Game/Content/Classes/Brightspark/BrightsparkPerks.cs
@@ -151,7 +151,9 @@ public class BrightsparkPerks
 				async parameters =>
 				{
 					AbilityCard selectedAbilityCard = await AbilityCmd.SelectAbilityCard(character, CardState.Hand,
+						canSelectFunc: card => card.Top.Model.Persistent || card.Bottom.Model.Persistent,
 						hintText: "Select a card to perform all persistent abilities on either the top or bottom action");
+
 					if(selectedAbilityCard == null)
 					{
 						return;
@@ -186,8 +188,8 @@ public class BrightsparkPerks
 					}
 
 					ScenarioEvents.AbilityStartedEvent.Subscribe(this,
-						abilityStartedParameters => abilityStartedParameters.AbilityState.ActionState.ActionSource == card.Top ||
-						                            abilityStartedParameters.AbilityState.ActionState.ActionSource == card.Bottom &&
+						abilityStartedParameters => (abilityStartedParameters.AbilityState.ActionState.ActionSource == card.Top ||
+						                            abilityStartedParameters.AbilityState.ActionState.ActionSource == card.Bottom) &&
 						                            abilityStartedParameters.AbilityState is not ActiveAbilityState,
 						async abilityStartedParameters =>
 						{

--- a/Game/Content/Classes/Brightspark/Cards/06_DynamicBalance.cs
+++ b/Game/Content/Classes/Brightspark/Cards/06_DynamicBalance.cs
@@ -36,7 +36,7 @@ public class DynamicBalance : BrightsparkCardModel<DynamicBalance.CardTop, Dynam
 								await GDTask.CompletedTask;
 							},
 							effectButtonParameters: new IconEffectButton.Parameters(Icons.Move),
-							effectInfoViewParameters: new TextEffectInfoView.Parameters($"{Icons.Inline(Icons.Move)}3"),
+							effectInfoViewParameters: new TextEffectInfoView.Parameters($"{Icons.Inline(Icons.Move)}2"),
 							effectType: EffectType.SelectableMandatory
 						),
 						ScenarioEvents.GenericChoice.Subscription.New(

--- a/Game/Content/Classes/FireKnight/FireKnight.cs
+++ b/Game/Content/Classes/FireKnight/FireKnight.cs
@@ -84,51 +84,15 @@ public partial class FireKnight : Character
 	{
 		object subscriber = new object();
 
-		ScenarioEvents.CardSideSelectionEvent.Subscribe(this, subscriber,
-			canApplyParameters => canApply(canApplyParameters.Character),
-			async applyParameters =>
+		AbilityCmd.SubscribeDuringCharacterTurn(ScenarioEvents.GetSubscriberPair(subscriber, this),
+			EffectType.Selectable,
+			character => canApply(character),
+			async character =>
 			{
 				await apply();
 			},
-			EffectType.Selectable,
 			order: 0,
-			canApplyMultipleTimesInEffectCollection: true,
-			effectButtonParameters: effectButtonParameters,
-			effectInfoViewParameters: effectInfoViewParameters);
-
-		ScenarioEvents.AfterCardsPlayedEvent.Subscribe(this, subscriber,
-			canApplyParameters => canApply(canApplyParameters.Character),
-			async applyParameters =>
-			{
-				await apply();
-			},
-			EffectType.Selectable,
-			order: 0,
-			canApplyMultipleTimesInEffectCollection: true,
-			effectButtonParameters: effectButtonParameters,
-			effectInfoViewParameters: effectInfoViewParameters);
-
-		ScenarioEvents.LongRestStartedEvent.Subscribe(this, subscriber,
-			canApplyParameters => canApply(canApplyParameters.Character),
-			async applyParameters =>
-			{
-				await apply();
-			},
-			EffectType.Selectable,
-			order: 0,
-			canApplyMultipleTimesInEffectCollection: true,
-			effectButtonParameters: effectButtonParameters,
-			effectInfoViewParameters: effectInfoViewParameters);
-
-		ScenarioEvents.DuringMovementEvent.Subscribe(this, subscriber,
-			canApplyParameters => canApplyParameters.Performer is Character character && canApply(character),
-			async applyParameters =>
-			{
-				await apply();
-			},
-			EffectType.Selectable,
-			order: 0,
-			canApplyMultipleTimesInEffectCollection: true,
+			canApplyMultipleTimesDuringAbility: true,
 			effectButtonParameters: effectButtonParameters,
 			effectInfoViewParameters: effectInfoViewParameters);
 	}

--- a/Game/Content/Classes/Luminary/Cards/09_TorridRadiation.cs
+++ b/Game/Content/Classes/Luminary/Cards/09_TorridRadiation.cs
@@ -24,19 +24,15 @@ public class TorridRadiation : LuminaryCardModel<TorridRadiation.CardTop, Torrid
 					]
 				))
 				.Build()),
-			new AbilityCardAbility(OtherAbility.Builder()
-				.WithPerformAbility(async state =>
-				{
-					await AbilityCmd.SufferDamage(state, state.ActionState.GetAbilityState<AttackAbility.State>(0).Target, 1);
-					state.SetPerformed();
-					await AbilityCmd.GainXP(state.Performer, 1);
-				})
+			new AbilityCardAbility(SufferDamageAbility.Builder()
+				.WithDamage(1)
+				.WithCustomGetTargets((state, figures) => figures.Add(state.ActionState.GetAbilityState<AttackAbility.State>(0).Target))
 				.WithConditionalAbilityCheck(async state =>
 				{
-					return state.ActionState.GetAbilityState<AttackAbility.State>(0).Performed &&
-							state.ActionState.GetAbilityState<AttackAbility.State>(0).Target != null &&
-							await AbilityCmd.AskConsumeElement(state.Performer, Element.Fire);
+					return await AbilityCmd.HasPerformedAbility(state, 0) &&
+					       await AbilityCmd.AskConsumeElement(state.Performer, Element.Fire);
 				})
+				.WithOnAbilityEndedPerformed(async state => await AbilityCmd.GainXP(state.Performer, 1))
 				.Build()),
 			Scuttle(1, [Element.Dark]),
 		];
@@ -49,16 +45,20 @@ public class TorridRadiation : LuminaryCardModel<TorridRadiation.CardTop, Torrid
 			new AbilityCardAbility(MoveAbility.Builder()
 				.WithDistance(3, new MoveCircle(this, new Vector2(0.6213844f, 0.6537314f)))
 				.Build()),
-			new AbilityCardAbility(OtherAbility.Builder()
-				.WithPerformAbility(async state =>
+			new AbilityCardAbility(SufferDamageAbility.Builder()
+				.WithDamage(1)
+				.WithCustomGetTargets((state, figures) =>
 				{
-					foreach(Figure figure in RangeHelper.GetFiguresInRange(state.Performer.Hex, 1, false)
-						.Where(figure => figure.EnemiesWith(state.Performer)))
-					{
-						await AbilityCmd.SufferDamage(state, figure, 1);
-						state.SetPerformed();
-					}
-
+					figures.AddRange(RangeHelper.GetFiguresInRange(state.Performer.Hex, 1, false)
+						        .Where(figure => figure.EnemiesWith(state.Performer)));
+				})
+				.WithTarget(Target.Enemies | Target.TargetAll)
+				.WithConditionalAbilityCheck(async state =>
+				{
+					return await AbilityCmd.AskConsumeElement(state.Performer, Element.Fire);
+				})
+				.WithOnAbilityEndedPerformed(async state =>
+				{
 					for(int i = 0; i < state.DamagedFigures.Count; i++)
 					{
 						await AbilityCmd.InfuseWildElement(state);

--- a/Game/Content/Classes/Luminary/Cards/09_TorridRadiation.cs
+++ b/Game/Content/Classes/Luminary/Cards/09_TorridRadiation.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using Godot;
 
@@ -33,8 +33,9 @@ public class TorridRadiation : LuminaryCardModel<TorridRadiation.CardTop, Torrid
 				})
 				.WithConditionalAbilityCheck(async state =>
 				{
-					return state.ActionState.GetAbilityState<AttackAbility.State>(0).Target != null &&
-					       await AbilityCmd.AskConsumeElement(state.Performer, Element.Fire);
+					return state.ActionState.GetAbilityState<AttackAbility.State>(0).Performed &&
+							state.ActionState.GetAbilityState<AttackAbility.State>(0).Target != null &&
+							await AbilityCmd.AskConsumeElement(state.Performer, Element.Fire);
 				})
 				.Build()),
 			Scuttle(1, [Element.Dark]),
@@ -52,7 +53,7 @@ public class TorridRadiation : LuminaryCardModel<TorridRadiation.CardTop, Torrid
 				.WithPerformAbility(async state =>
 				{
 					foreach(Figure figure in RangeHelper.GetFiguresInRange(state.Performer.Hex, 1, false)
-						        .Where(figure => figure.EnemiesWith(state.Performer)))
+						.Where(figure => figure.EnemiesWith(state.Performer)))
 					{
 						await AbilityCmd.SufferDamage(state, figure, 1);
 						state.SetPerformed();

--- a/Game/Content/Classes/Luminary/Cards/13_TricklingSting.cs
+++ b/Game/Content/Classes/Luminary/Cards/13_TricklingSting.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using Fractural.Tasks;
 using Godot;
@@ -51,7 +51,7 @@ public class TricklingSting : LuminaryCardModel<TricklingSting.CardTop, Tricklin
 			new AbilityCardAbility(OtherActiveAbility.Builder()
 				.WithOnActivate(async state =>
 				{
-					CreateTrapAbility.State createTrapState = state.ActionState.GetAbilityState<CreateTrapAbility.State>(0);
+					CreateTrapAbility.State createTrapState = state.ActionState.GetAbilityState<CreateTrapAbility.State>(1);
 
 					ScenarioEvents.TrapTriggeredEvent.Subscribe(state, this,
 						canApply: canApplyParameters => createTrapState.CreatedTraps.Contains(canApplyParameters.Trap),

--- a/Game/Content/Classes/Luminary/Cards/14_DarkenedOvercast.cs
+++ b/Game/Content/Classes/Luminary/Cards/14_DarkenedOvercast.cs
@@ -29,7 +29,7 @@ public class DarkenedOvercast : LuminaryCardModel<DarkenedOvercast.CardTop, Dark
 				})
 				.WithOnDeactivate(async state =>
 				{
-					ScenarioEvents.AttackAfterTargetConfirmedEvent.Unsubscribe(state, this);
+					ScenarioEvents.DuringAttackEvent.Unsubscribe(state, this);
 
 					await GDTask.CompletedTask;
 				})

--- a/Game/Content/Classes/Luminary/GlowActiveAbility.cs
+++ b/Game/Content/Classes/Luminary/GlowActiveAbility.cs
@@ -47,6 +47,15 @@ public class GlowActiveAbility : ActiveAbility<GlowActiveAbility.State>
 	{
 		await base.Activate(abilityState);
 
+		ActionState actionState = ((Character)abilityState.Performer).Cards
+			.SelectMany(card => card.ActiveActionStates)
+			.FirstOrDefault(actionState => actionState.AbilityStates.Any(state => state is State && state != abilityState));
+
+		if(actionState != null)
+		{
+			await actionState.RequestDiscardOrLose();
+		}
+
 		AbilityCmd.SubscribeDuringCharacterTurn(ScenarioEvents.GetSubscriberPair(abilityState, this), EffectType.Selectable,
 			character => character == abilityState.Performer &&
 			             GlowAbilities.Any(glowAbility =>

--- a/Game/Content/Classes/Luminary/GlowActiveAbility.cs
+++ b/Game/Content/Classes/Luminary/GlowActiveAbility.cs
@@ -46,14 +46,6 @@ public class GlowActiveAbility : ActiveAbility<GlowActiveAbility.State>
 	protected override async GDTask Activate(State abilityState)
 	{
 		await base.Activate(abilityState);
-		ActionState actionState = ((Character)abilityState.Performer).Cards
-			.SelectMany(card => card.ActiveActionStates)
-			.FirstOrDefault(actionState => actionState.AbilityStates.Any(state => state is State));
-
-		if(actionState != null)
-		{
-			await actionState.RequestDiscardOrLose();
-		}
 
 		AbilityCmd.SubscribeDuringCharacterTurn(ScenarioEvents.GetSubscriberPair(abilityState, this), EffectType.Selectable,
 			character => character == abilityState.Performer &&

--- a/Game/Scripts/Scenario/Abilities/AbilityCmd.cs
+++ b/Game/Scripts/Scenario/Abilities/AbilityCmd.cs
@@ -18,9 +18,6 @@ public static class AbilityCmd
 
 	public static async GDTask LoseCard(AbilityCard card)
 	{
-		await ScenarioEvents.LostCardEvent.CreatePrompt(
-			new ScenarioEvents.LostCard.Parameters(card.Owner, card));
-
 		await card.RemoveFromActive();
 
 		if(card.Unrecoverable)

--- a/Game/Scripts/Scenario/Abilities/AbilityCmd.cs
+++ b/Game/Scripts/Scenario/Abilities/AbilityCmd.cs
@@ -1426,6 +1426,18 @@ public static class AbilityCmd
 			canApplyMultipleTimesInEffectCollection: canApplyMultipleTimesDuringAbility,
 			effectButtonParameters: effectButtonParameters,
 			effectInfoViewParameters: effectInfoViewParameters);
+
+		ScenarioEvents.DuringMovementEvent.Subscribe(eventSubscriber,
+			canApplyParameters => canApplyParameters.Performer is Character character && canApply(character),
+			async applyParameters =>
+			{
+				await apply(applyParameters.Performer as Character);
+			},
+			EffectType.Selectable,
+			order: 0,
+			canApplyMultipleTimesInEffectCollection: true,
+			effectButtonParameters: effectButtonParameters,
+			effectInfoViewParameters: effectInfoViewParameters);
 	}
 
 	public static void UnsubscribeDuringCharacterTurn(IEventSubscriber eventSubscriber)
@@ -1433,6 +1445,7 @@ public static class AbilityCmd
 		ScenarioEvents.CardSideSelectionEvent.Unsubscribe(eventSubscriber);
 		ScenarioEvents.AfterCardsPlayedEvent.Unsubscribe(eventSubscriber);
 		ScenarioEvents.LongRestCardSelectionEvent.Unsubscribe(eventSubscriber);
+		ScenarioEvents.DuringMovementEvent.Unsubscribe(eventSubscriber);
 	}
 
 	public static async GDTask AddShield(Figure figure, object subscriber, int shieldValue, bool conditionalValue = false, bool pierceable = true,

--- a/Game/Scripts/Scenario/ScenarioEvents/ScenarioEvents.cs
+++ b/Game/Scripts/Scenario/ScenarioEvents/ScenarioEvents.cs
@@ -1398,19 +1398,6 @@ public partial class ScenarioEvents
 	private readonly GainedExperience _gainedExperience = new GainedExperience();
 	public static GainedExperience GainedExperienceEvent => GameController.Instance.ScenarioEvents._gainedExperience;
 
-	public class LostCard : ScenarioEvent<LostCard.Parameters>
-	{
-		public class Parameters(Character character, AbilityCard card)
-			: ParametersBase
-		{
-			public Character Character { get; } = character;
-			public AbilityCard Card { get; } = card;
-		}
-	}
-
-	private readonly LostCard _lostCard = new LostCard();
-	public static LostCard LostCardEvent => GameController.Instance.ScenarioEvents._lostCard;
-
 	public class InflictConditionEventReward : ScenarioEvent<InflictConditionEventReward.Parameters>
 	{
 		public class Parameters(Character character, ConditionModel conditionModel)

--- a/Game/Scripts/Scenario/UI/CardPlayView/CardPlayCard.cs
+++ b/Game/Scripts/Scenario/UI/CardPlayView/CardPlayCard.cs
@@ -54,6 +54,8 @@ public partial class CardPlayCard : Control
 
 			_basicTopButton.SetVisible(cardData.CanPlayBasicTop);
 			_basicBottomButton.SetVisible(cardData.CanPlayBasicBottom);
+
+			SetVisible(true);
 		}
 	}
 


### PR DESCRIPTION
1. Fixes daredevil battle goal - the extra event was not needed and was not working well.
2. Fixes glow active ability immediately discarding itself.
3. Make DuringTurn subscription include DuringMovement. This affects quite some abilities, let me know if you want to have it separate for some.
4. Fix visual glitch where after using AbilityCardSectionSelectionPrompt with one card, the next time only one will be visible, even if the choice is already 2.
5. Fix movement amount typo in Dynamic Balance
6. Fix Brightspart perk not giving the right card choice
7. Fix crash with Trickling Sting
8. DarkenedOvercast never ending
9. Fix torrid radiation giving double kill credit with element consumption, rework into SufferDamageAbility
10. Fix ritualist battle goal 1 number off
11. Fix brightspark amd wrong atlas index