### PR TITLE
Bug fixes

### DIFF
--- a/Game/Content/BattleGoals/11_Dawdler.cs
+++ b/Game/Content/BattleGoals/11_Dawdler.cs
@@ -17,6 +17,7 @@ public class Dawdler : TheCrimsonScalesBattleGoal
 			parameters =>
 				!battleGoal.ProgressFull &&
 				!character.IsDead &&
+				!character.LongResting &&
 				character.RoundCards[0].Model.Initiative < character.RoundCards[1].Model.Initiative,
 			async parameters =>
 			{

--- a/Game/Content/Classes/Brightspark/Cards/14_NutrientOverdose.cs
+++ b/Game/Content/Classes/Brightspark/Cards/14_NutrientOverdose.cs
@@ -19,7 +19,7 @@ public class NutrientOverdose : BrightsparkCardModel<NutrientOverdose.CardTop, N
 				.WithDuringAttackSubscription(
 					ScenarioEvents.DuringAttack.Subscription.New(
 						parameters => parameters.Performer is Character character && character.RoundCardData.Any(roundCardData =>
-							roundCardData.AbilityCard.Model != AbilityCardModel && roundCardData.CanPlayBasicBottom || roundCardData.CanPlayBottom),
+							roundCardData.AbilityCard.Model != AbilityCardModel && (roundCardData.CanPlayBasicBottom || roundCardData.CanPlayBottom)),
 						async parameters =>
 						{
 							foreach(CardPlayCardData cardData in ((Character)parameters.Performer).RoundCardData)
@@ -48,7 +48,7 @@ public class NutrientOverdose : BrightsparkCardModel<NutrientOverdose.CardTop, N
 				.WithDuringMovementSubscription(
 					ScenarioEvents.DuringMovement.Subscription.New(
 						parameters => parameters.Performer is Character character && character.RoundCardData.Any(roundCardData =>
-							roundCardData.AbilityCard.Model != AbilityCardModel && roundCardData.CanPlayBasicTop || roundCardData.CanPlayTop),
+							roundCardData.AbilityCard.Model != AbilityCardModel && (roundCardData.CanPlayBasicTop || roundCardData.CanPlayTop)),
 						async parameters =>
 						{
 							foreach(CardPlayCardData cardData in ((Character)parameters.Performer).RoundCardData)

--- a/Game/Content/Classes/Chainguard/Cards/17_DizzyingRelease.cs
+++ b/Game/Content/Classes/Chainguard/Cards/17_DizzyingRelease.cs
@@ -13,21 +13,38 @@ public class DizzyingRelease : ChainguardLevelUpCardModel<DizzyingRelease.CardTo
 	{
 		protected override List<AbilityCardAbility> GetAbilities() =>
 		[
+			new AbilityCardAbility(OtherAbility.Builder()
+				.WithPerformAbility(async state =>
+				{
+					Figure figure = await AbilityCmd.SelectFigure(state,
+						list =>
+						{
+							list.AddRange(RangeHelper.GetFiguresInRange(state.Performer.Hex, 1, includeOrigin: false)
+								.Where(figure => figure.EnemiesWith(state.Performer) && figure.HasCondition(Chainguard.Shackle)));
+						}, hintText: () => $"Designate an adjacent enemy with {Icons.Inline(Icons.GetCondition(Chainguard.Shackle))}");
+
+					if(figure != null)
+					{
+						state.SetCustomValue(this, "DesignatedEnemy", figure);
+						state.SetPerformed();
+					}
+				})
+				.Build()),
+
 			new AbilityCardAbility(SwingAbility.Builder()
 				.WithSwing(6)
 				.WithCustomGetTargets((state, figures) =>
 				{
-					IEnumerable<Figure> adjacentFigures = RangeHelper.GetFiguresInRange(state.Performer.Hex, 1, includeOrigin: false);
-					figures.AddRange(adjacentFigures.Where(figure => figure.EnemiesWith(state.Performer) && figure.HasCondition(Chainguard.Shackle)));
+					figures.Add(state.ActionState.GetAbilityState<OtherAbility.State>(0).GetCustomValue<Figure>(this, "DesignatedEnemy"));
 				})
+				.WithConditionalAbilityCheck(state => AbilityCmd.HasPerformedAbility(state, 0))
 				.Build()),
 
 			new AbilityCardAbility(PushAbility.Builder()
 				.WithPush(3)
 				.WithCustomGetTargets((state, figures) =>
 				{
-					SwingAbility.State swingAbilityState = state.ActionState.GetAbilityState<SwingAbility.State>(0);
-					figures.AddRange(swingAbilityState.UniqueTargetedFigures);
+					figures.Add(state.ActionState.GetAbilityState<OtherAbility.State>(0).GetCustomValue<Figure>(this, "DesignatedEnemy"));
 				})
 				.WithConditionalAbilityCheck(state => AbilityCmd.HasPerformedAbility(state, 0))
 				.Build()),
@@ -36,12 +53,16 @@ public class DizzyingRelease : ChainguardLevelUpCardModel<DizzyingRelease.CardTo
 				.WithSwing(0)
 				.WithCustomGetTargets((state, figures) =>
 				{
-					SwingAbility.State swingAbilityState = state.ActionState.GetAbilityState<SwingAbility.State>(0);
-					figures.AddRange(swingAbilityState.UniqueTargetedFigures);
+					figures.Add(state.ActionState.GetAbilityState<OtherAbility.State>(0).GetCustomValue<Figure>(this, "DesignatedEnemy"));
 				})
 				.WithOnAbilityStarted(async state =>
 				{
-					SwingAbility.State swingAbilityState = state.ActionState.GetAbilityState<SwingAbility.State>(0);
+					if(!await AbilityCmd.HasPerformedAbility(state, 0))
+					{
+						return;
+					}
+
+					SwingAbility.State swingAbilityState = state.ActionState.GetAbilityState<SwingAbility.State>(1);
 					int remainingSwing = swingAbilityState.AbilitySwing - swingAbilityState.SingleTargetState.ForcedMovementHexes.Count;
 					state.AbilityAdjustSwing(remainingSwing);
 
@@ -66,12 +87,15 @@ public class DizzyingRelease : ChainguardLevelUpCardModel<DizzyingRelease.CardTo
 				})
 				.WithConditionalAbilityCheck(async state =>
 				{
-					SwingAbility.State swingAbilityState = state.ActionState.GetAbilityState<SwingAbility.State>(0);
+					if(!await AbilityCmd.HasPerformedAbility(state, 0))
+					{
+						return false;
+					}
+
+					SwingAbility.State swingAbilityState = state.ActionState.GetAbilityState<SwingAbility.State>(1);
 					int remainingSwing = swingAbilityState.AbilitySwing - swingAbilityState.SingleTargetState.ForcedMovementHexes.Count;
 
-					await GDTask.CompletedTask;
-
-					return swingAbilityState.Performed && remainingSwing > 0;
+					return remainingSwing > 0;
 				})
 				.WithOnAbilityEnded(async state =>
 				{
@@ -85,20 +109,20 @@ public class DizzyingRelease : ChainguardLevelUpCardModel<DizzyingRelease.CardTo
 				.WithDamage(0)
 				.WithCustomGetTargets((state, figures) =>
 				{
-					SwingAbility.State swingAbilityState = state.ActionState.GetAbilityState<SwingAbility.State>(0);
-					figures.AddRange(swingAbilityState.UniqueTargetedFigures);
+					figures.Add(state.ActionState.GetAbilityState<OtherAbility.State>(0).GetCustomValue<Figure>(this, "DesignatedEnemy"));
 				})
-				.WithOnAbilityStarted(async state =>
-				{
-					SwingAbility.State firstState = state.ActionState.GetAbilityState<SwingAbility.State>(0);
-					PushAbility.State secondState = state.ActionState.GetAbilityState<PushAbility.State>(1);
-					SwingAbility.State thirdState = state.ActionState.GetAbilityState<SwingAbility.State>(2);
-					state.AbilityAdjustAttackValue(firstState.SingleTargetState.ForcedMovementHexes.Count +
-					                               secondState.SingleTargetState.ForcedMovementHexes.Count +
-					                               thirdState.SingleTargetState.ForcedMovementHexes.Count);
+				.WithDuringAttackSubscription(ScenarioEvents.DuringAttack.Subscription.New(
+					applyFunction: async parameters =>
+					{
+						SwingAbility.State firstState = parameters.AbilityState.ActionState.GetAbilityState<SwingAbility.State>(1);
+						PushAbility.State secondState = parameters.AbilityState.ActionState.GetAbilityState<PushAbility.State>(2);
+						SwingAbility.State thirdState = parameters.AbilityState.ActionState.GetAbilityState<SwingAbility.State>(3);
+						parameters.AbilityState.AbilityAdjustAttackValue(firstState.SingleTargetState.ForcedMovementHexes.Count +
+						                                                  secondState.SingleTargetState.ForcedMovementHexes.Count +
+						                                                  thirdState.SingleTargetState.ForcedMovementHexes.Count);
 
-					await GDTask.CompletedTask;
-				})
+						await GDTask.CompletedTask;
+					}))
 				.WithConditionalAbilityCheck(state => AbilityCmd.HasPerformedAbility(state, 0))
 				.Build()),
 		];

--- a/Game/Content/Classes/SpiritCaller/AMDCards/SpiritCallerAMDCards.cs
+++ b/Game/Content/Classes/SpiritCaller/AMDCards/SpiritCallerAMDCards.cs
@@ -74,7 +74,7 @@ public class SpiritCallerAMDCards
 
 	public class PlusOneCurse : SpiritCallerAMDCardModel
 	{
-		protected override int AtlasIndex => 15;
+		protected override int AtlasIndex => 14;
 		public override int? GetValue(AttackAbility.State attackAbilityState) => +1;
 		public override List<ConditionModel> GetConditionModels(AttackAbility.State attackAbilityState) => [Conditions.Curse];
 	}

--- a/Game/Content/Classes/SpiritCaller/Cards/00_BurningPit.cs
+++ b/Game/Content/Classes/SpiritCaller/Cards/00_BurningPit.cs
@@ -36,7 +36,7 @@ public class BurningPit : SpiritCallerCardModel<BurningPit.CardTop, BurningPit.C
 								GameController.Instance.ElementManager.GetState(Element.Fire) > ElementState.Inert ? 4 : 3);
 
 							await state.ActionState.RequestDiscardOrLose();
-						}
+						}, order: 1
 					);
 
 					await GDTask.CompletedTask;

--- a/Game/Content/Classes/SpiritCaller/Cards/00_BurningPit.cs
+++ b/Game/Content/Classes/SpiritCaller/Cards/00_BurningPit.cs
@@ -34,6 +34,8 @@ public class BurningPit : SpiritCallerCardModel<BurningPit.CardTop, BurningPit.C
 
 							await AbilityCmd.SufferDamage(state, parameters.Figure,
 								GameController.Instance.ElementManager.GetState(Element.Fire) > ElementState.Inert ? 4 : 3);
+
+							await state.ActionState.RequestDiscardOrLose();
 						}
 					);
 

--- a/Game/Content/Classes/SpiritCaller/Cards/03_EtherealCanine.cs
+++ b/Game/Content/Classes/SpiritCaller/Cards/03_EtherealCanine.cs
@@ -73,7 +73,7 @@ public class EtherealCanine : SpiritCallerCardModel<EtherealCanine.CardTop, Ethe
 						textParameters =>
 							$"This Spirit adds +{attackBonus}{Icons.Inline(Icons.Attack, textParameters)} to its next attack this round.");
 
-					ScenarioEvents.AttackAfterTargetConfirmedEvent.Subscribe(state, this,
+					ScenarioEvents.DuringAttackEvent.Subscribe(state, this,
 						parameters =>
 							parameters.AbilityState.Performer == spirit,
 						async parameters =>
@@ -90,7 +90,7 @@ public class EtherealCanine : SpiritCallerCardModel<EtherealCanine.CardTop, Ethe
 
 					await AbilityCmd.RemoveCharacterToken(state, spirit);
 
-					ScenarioEvents.AttackAfterTargetConfirmedEvent.Unsubscribe(state, this);
+					ScenarioEvents.DuringAttackEvent.Unsubscribe(state, this);
 				})
 				.WithSkipConfirmation()
 				.WithConditionalAbilityCheck(async state =>

--- a/Game/Content/Classes/SpiritCaller/Cards/03_EtherealCanine.cs
+++ b/Game/Content/Classes/SpiritCaller/Cards/03_EtherealCanine.cs
@@ -78,7 +78,7 @@ public class EtherealCanine : SpiritCallerCardModel<EtherealCanine.CardTop, Ethe
 							parameters.AbilityState.Performer == spirit,
 						async parameters =>
 						{
-							parameters.AbilityState.AbilityAdjustAttackValue(attackBonus);
+							parameters.AbilityState.SingleTargetAdjustAttackValue(attackBonus);
 
 							await state.ActionState.RequestDiscardOrLose();
 						}

--- a/Game/Content/Classes/SpiritCaller/Cards/04_HordeOfBones.cs
+++ b/Game/Content/Classes/SpiritCaller/Cards/04_HordeOfBones.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 
 public class HordeOfBones : SpiritCallerCardModel<HordeOfBones.CardTop, HordeOfBones.CardBottom>
 {
@@ -32,9 +33,25 @@ public class HordeOfBones : SpiritCallerCardModel<HordeOfBones.CardTop, HordeOfB
 	{
 		protected override List<AbilityCardAbility> GetAbilities() =>
 		[
-			new AbilityCardAbility(TeleportAbility.Builder()
-				.WithDistance(3)
-				.WithFilterHexes((state, hex) => hex.HasHexObjectOfType<Coin>())
+			new AbilityCardAbility(OtherAbility.Builder()
+				.WithPerformAbility(async state =>
+				{
+					Hex swapped = await AbilityCmd.SelectHex(state, list =>
+					{
+						list.AddRange(RangeHelper.GetHexesInRange(state.Performer.Hex, 3, requiresLineOfSight: false)
+							.Where(hex => hex.HasHexObjectOfType<Coin>() && AbilityCmd.CanSwap(state.Performer, hex.GetHexObjectOfType<Coin>())));
+					}, mandatory: false, "Select a coin token to swap hexes with.");
+
+					if(swapped == null)
+					{
+						return;
+					}
+
+					if(await AbilityCmd.TrySwap(state, state.Performer, swapped.GetHexObjectOfType<Coin>()))
+					{
+						state.SetPerformed();
+					}
+				})
 				.WithConditionalAbilityCheck(state => AbilityCmd.AskConsumeElement(state.Performer, Element.Dark))
 				.Build()),
 

--- a/Game/Content/Classes/SpiritCaller/Cards/06_MidnightFeast.cs
+++ b/Game/Content/Classes/SpiritCaller/Cards/06_MidnightFeast.cs
@@ -67,7 +67,7 @@ public class MidnightFeast : SpiritCallerCardModel<MidnightFeast.CardTop, Midnig
 				})
 				.WithOnDeactivate(async state =>
 				{
-					ScenarioEvents.HexObjectDestroyedEvent.Unsubscribe(state, this);
+					ScenarioEvents.FigureKilledEvent.Unsubscribe(state, this);
 
 					await GDTask.CompletedTask;
 				})

--- a/Game/Content/Classes/SpiritCaller/Cards/14_SmokyShroud.cs
+++ b/Game/Content/Classes/SpiritCaller/Cards/14_SmokyShroud.cs
@@ -108,7 +108,7 @@ public class SmokyShroud : SpiritCallerCardModel<SmokyShroud.CardTop, SmokyShrou
 
 							await GDTask.CompletedTask;
 						}))
-				.WithOnAbilityEndedPerformed(async state =>
+				.WithOnAbilityEnded(async state =>
 				{
 					ScenarioEvents.FigureEnteredHexEvent.Unsubscribe(state, this);
 

--- a/Game/Content/Classes/SpiritCaller/Cards/14_SmokyShroud.cs
+++ b/Game/Content/Classes/SpiritCaller/Cards/14_SmokyShroud.cs
@@ -7,7 +7,7 @@ public class SmokyShroud : SpiritCallerCardModel<SmokyShroud.CardTop, SmokyShrou
 	public override string Name => "Smoky Shroud";
 	public override int Level => 2;
 	public override int Initiative => 81;
-	protected override int AtlasIndex => 28 - 13;
+	protected override int AtlasIndex => 28 - 14;
 
 	public class CardTop : SpiritCallerCardSide
 	{

--- a/Game/Content/Classes/SpiritCaller/Cards/14_SmokyShroud.cs
+++ b/Game/Content/Classes/SpiritCaller/Cards/14_SmokyShroud.cs
@@ -89,7 +89,31 @@ public class SmokyShroud : SpiritCallerCardModel<SmokyShroud.CardTop, SmokyShrou
 
 							await GDTask.CompletedTask;
 						},
-						effectInfoViewParameters: new TextEffectInfoView.Parameters($"+2{Icons.Inline(Icons.Push)}")))
+						effectInfoViewParameters: new TextEffectInfoView.Parameters($"+2{Icons.Inline(Icons.Push)}")),
+					ScenarioEvents.DuringPush.Subscription.New(
+						applyFunction: async applyParameters =>
+						{
+							ScenarioEvents.FigureEnteredHexEvent.Subscribe(applyParameters.AbilityState, this,
+								parameters =>
+									parameters.Figure == applyParameters.AbilityState.Target &&
+									parameters.PotentialAbilityState == applyParameters.AbilityState &&
+									parameters.Hex.HasHexObjectOfType<Spirit>(),
+								async parameters =>
+								{
+									parameters.PotentialAbilityState.SetCustomValue(this, "PushedIntoSpirit", true);
+
+									await GDTask.CompletedTask;
+								}
+							);
+
+							await GDTask.CompletedTask;
+						}))
+				.WithOnAbilityEndedPerformed(async state =>
+				{
+					ScenarioEvents.FigureEnteredHexEvent.Unsubscribe(state, this);
+
+					await GDTask.CompletedTask;
+				})
 				.Build()),
 
 			new AbilityCardAbility(SufferDamageAbility.Builder()
@@ -97,16 +121,9 @@ public class SmokyShroud : SpiritCallerCardModel<SmokyShroud.CardTop, SmokyShrou
 				.WithCustomGetTargets((state, list) =>
 				{
 					PushAbility.State pushAbilityState = state.ActionState.GetAbilityState<PushAbility.State>(1);
-					foreach(SingleTargetState singleTargetState in pushAbilityState.SingleTargetStates)
+					if(pushAbilityState.GetCustomValue<bool>(this, "PushedIntoSpirit"))
 					{
-						foreach(Hex pushHex in singleTargetState.PushHexes)
-						{
-							if(Spirit.HasSpirit(pushHex))
-							{
-								list.Add(singleTargetState.Target);
-								break;
-							}
-						}
+						list.Add(pushAbilityState.Target);
 					}
 				})
 				.WithConditionalAbilityCheck(state => AbilityCmd.HasPerformedAbility(state, 1))

--- a/Game/Content/Classes/SpiritCaller/Cards/17_SpiritBarrage.cs
+++ b/Game/Content/Classes/SpiritCaller/Cards/17_SpiritBarrage.cs
@@ -22,7 +22,8 @@ public class SpiritBarrage : SpiritCallerCardModel<SpiritBarrage.CardTop, Spirit
 							parameters.AbilityState.AdjustTargets(1);
 
 							await GainXP(parameters.AbilityState);
-						}))
+						},
+						effectInfoViewParameters: new TextEffectInfoView.Parameters($"+1{Icons.Inline(Icons.Targets)}")))
 				.WithOnAbilityStarted(async state =>
 				{
 					Figure spirit = await Spirit.SelectSpirit(state);

--- a/Game/Content/Classes/SpiritCaller/Cards/17_SpiritBarrage.cs
+++ b/Game/Content/Classes/SpiritCaller/Cards/17_SpiritBarrage.cs
@@ -82,7 +82,10 @@ public class SpiritBarrage : SpiritCallerCardModel<SpiritBarrage.CardTop, Spirit
 						return;
 					}
 
-					await AbilityCmd.TrySwap(state, spirit, swapped);
+					if(await AbilityCmd.TrySwap(state, spirit, swapped))
+					{
+						state.SetPerformed();
+					}
 				})
 				.Build())
 		];

--- a/Game/Content/Classes/SpiritCaller/Spirit.cs
+++ b/Game/Content/Classes/SpiritCaller/Spirit.cs
@@ -96,7 +96,7 @@ public partial class Spirit : Figure
 					}
 					else
 					{
-						parameters.SetAlliedWith();
+						parameters.SetEnemiesWith();
 						return;
 					}
 				}

--- a/Game/Content/Classes/SpiritCaller/Spirit.cs
+++ b/Game/Content/Classes/SpiritCaller/Spirit.cs
@@ -94,7 +94,7 @@ public partial class Spirit : Figure
 						parameters.SetAlliedWith();
 						return;
 					}
-					else
+					else if(parameters.OtherFigure.Alignment is Alignment.Monsters or Alignment.Other)
 					{
 						parameters.SetEnemiesWith();
 						return;

--- a/Game/Content/Classes/SpiritCaller/Spirit.cs
+++ b/Game/Content/Classes/SpiritCaller/Spirit.cs
@@ -175,6 +175,14 @@ public partial class Spirit : Figure
 			}
 		);
 
+		ScenarioEvents.RetaliateEvent.Subscribe(this, CharacterOwner,
+			parameters => parameters.AbilityState.Performer == this,
+			async parameters =>
+			{
+				parameters.SetRetaliateBlocked();
+				await GDTask.CompletedTask;
+			});
+
 		ScenarioCheckEvents.FlyingCheckEvent.Subscribe(this, CharacterOwner,
 			parameters => parameters.Figure == this,
 			parameters => parameters.SetFlying(true)
@@ -264,6 +272,7 @@ public partial class Spirit : Figure
 		ScenarioEvents.HexObjectDestroyedEvent.Unsubscribe(this, CharacterOwner);
 		ScenarioEvents.FigureEnteredHexEvent.Unsubscribe(this, CharacterOwner);
 		ScenarioEvents.FigureExitingHexEvent.Unsubscribe(this, CharacterOwner);
+		ScenarioEvents.RetaliateEvent.Unsubscribe(this, CharacterOwner);
 		ScenarioCheckEvents.FlyingCheckEvent.Unsubscribe(this, CharacterOwner);
 		ScenarioCheckEvents.CanBeFocusedCheckEvent.Unsubscribe(this, CharacterOwner);
 		//ScenarioCheckEvents.CanBeTargetedCheckEvent.Unsubscribe(this, CharacterOwner);

--- a/Game/Content/Classes/SpiritCaller/SpiritCallerPerks.cs
+++ b/Game/Content/Classes/SpiritCaller/SpiritCallerPerks.cs
@@ -44,7 +44,6 @@ public class SpiritCallerPerks
 
 		public override List<AMDCardModel> CardsToAdd { get; } =
 		[
-			ModelDB.AMDCard<PlusZeroAMDCard>(),
 			ModelDB.AMDCard<SpiritCallerAMDCards.PlusZeroPoisonRolling>()
 		];
 	}

--- a/Game/Content/Classes/SpiritCaller/SpiritCallerPerks.cs
+++ b/Game/Content/Classes/SpiritCaller/SpiritCallerPerks.cs
@@ -44,7 +44,8 @@ public class SpiritCallerPerks
 
 		public override List<AMDCardModel> CardsToAdd { get; } =
 		[
-			ModelDB.AMDCard<SpiritCallerAMDCards.PlusZeroPlusTwoIfSpiritAttacked>()
+			ModelDB.AMDCard<PlusZeroAMDCard>(),
+			ModelDB.AMDCard<SpiritCallerAMDCards.PlusZeroPoisonRolling>()
 		];
 	}
 

--- a/Game/Content/Classes/Starslinger/Cards/21_AbsoluteMagnitude.cs
+++ b/Game/Content/Classes/Starslinger/Cards/21_AbsoluteMagnitude.cs
@@ -36,6 +36,7 @@ public class AbsoluteMagnitude : StarslingerCardModel<AbsoluteMagnitude.CardTop,
 					if(await AbilityCmd.TrySwap(state, state.Performer, swapped))
 					{
 						await AbilityCmd.GainXP(state.Performer, 1);
+						state.SetPerformed();
 					}
 				})
 				.Build())

--- a/Game/Content/Classes/Starslinger/Cards/27_InterplanarVoyage.cs
+++ b/Game/Content/Classes/Starslinger/Cards/27_InterplanarVoyage.cs
@@ -63,7 +63,10 @@ public class InterplanarVoyage : StarslingerCardModel<InterplanarVoyage.CardTop,
 						return;
 					}
 
-					await AbilityCmd.TrySwap(state, state.Performer, swapped);
+					if(await AbilityCmd.TrySwap(state, state.Performer, swapped))
+					{
+						state.SetPerformed();
+					}
 				})
 				.Build())
 		];
@@ -94,7 +97,10 @@ public class InterplanarVoyage : StarslingerCardModel<InterplanarVoyage.CardTop,
 						return;
 					}
 
-					await AbilityCmd.TrySwap(state, state.Performer, swapped);
+					if(await AbilityCmd.TrySwap(state, state.Performer, swapped))
+					{
+						state.SetPerformed();
+					}
 				})
 				.Build())
 		];

--- a/Game/Content/Items/Prosperity3/028_MoonEarring.cs
+++ b/Game/Content/Items/Prosperity3/028_MoonEarring.cs
@@ -1,4 +1,4 @@
-public class MoonEarring : Prosperity1Item
+public class MoonEarring : Prosperity3Item
 {
 	public override string Name => "Moon Earring";
 	public override int ItemNumber => 28;
@@ -7,7 +7,7 @@ public class MoonEarring : Prosperity1Item
 	public override ItemType ItemType => ItemType.Small;
 	public override ItemUseType ItemUseType => ItemUseType.Consume;
 
-	protected override int AtlasIndex => 10;
+	protected override int AtlasIndex => 14;
 
 	protected override void Subscribe()
 	{

--- a/Game/Scripts/Scenario/Abilities/AbilityCmd.cs
+++ b/Game/Scripts/Scenario/Abilities/AbilityCmd.cs
@@ -745,24 +745,34 @@ public static class AbilityCmd
 			triggerHexEffects: true, setPosition: true, forcedMovement: forcedMovement);
 	}
 
-	public static GDTask<bool> TrySwap(Figure authority, Figure figureA, Figure figureB)
+	public static GDTask<bool> TrySwap(Figure authority, HexObject hexObjectA, HexObject hexObjectB)
 	{
-		return TrySwap(null, authority, figureA, figureB);
+		return TrySwap(null, authority, hexObjectA, hexObjectB);
 	}
 
-	public static GDTask<bool> TrySwap(AbilityState abilityState, Figure figureA, Figure figureB)
+	public static GDTask<bool> TrySwap(AbilityState abilityState, HexObject hexObjectA, HexObject hexObjectB)
 	{
-		return TrySwap(abilityState, abilityState.Authority, figureA, figureB);
+		return TrySwap(abilityState, abilityState.Authority, hexObjectA, hexObjectB);
 	}
 
-	public static bool CanSwap(Figure figureA, Figure figureB)
+	public static bool CanSwap(HexObject hexObjectA, HexObject hexObjectB)
 	{
-		if(figureA == figureB)
+		if(hexObjectA == hexObjectB)
 		{
 			return false;
 		}
 
-		return CanForceMoveTo(figureA, figureB.Hex) && CanForceMoveTo(figureB, figureA.Hex);
+		if(hexObjectA is Figure figureA && !CanForceMoveTo(figureA, hexObjectB.Hex))
+		{
+			return false;
+		}
+
+		if(hexObjectB is Figure figureB && !CanForceMoveTo(figureB, hexObjectA.Hex))
+		{
+			return false;
+		}
+
+		return true;
 
 		// if(figureA.Hex.TryGetHexObjectOfType(out Obstacle obstacle) &&
 		//    !ScenarioCheckEvents.FlyingCheckEvent.Fire(new ScenarioCheckEvents.FlyingCheck.Parameters(figureB)).HasFlying)
@@ -1617,28 +1627,50 @@ public static class AbilityCmd
 		return success;
 	}
 
-	private static async GDTask<bool> TrySwap(AbilityState potentialAbilityState, Figure authority, Figure figureA, Figure figureB)
+	private static async GDTask<bool> TrySwap(AbilityState potentialAbilityState, Figure authority, HexObject hexObjectA, HexObject hexObjectB)
 	{
-		if(!CanSwap(figureA, figureB))
+		if(!CanSwap(hexObjectA, hexObjectB))
 		{
 			return false;
 		}
 
 		if(!GameController.FastForward)
 		{
-			await GameController.Instance.ScreenDistortion.Swap(figureA, figureB, 1.4f).PlayFastForwardableAsync();
+			await GameController.Instance.ScreenDistortion.Swap(hexObjectA, hexObjectB, 1.4f).PlayFastForwardableAsync();
 		}
 
-		Hex hexA = figureA.Hex;
-		Hex hexB = figureB.Hex;
+		Hex hexA = hexObjectA.Hex;
+		Hex hexB = hexObjectB.Hex;
 
-		await ExitHex(potentialAbilityState, figureA, authority);
-		await ExitHex(potentialAbilityState, figureB, authority);
-		await EnterHex(potentialAbilityState, figureB, authority, hexA,
-			triggerHexEffects: true, setPosition: true, forcedMovement: figureB.EnemiesWith(authority));
-		await EnterHex(potentialAbilityState, figureA, authority, hexB,
-			triggerHexEffects: true, setPosition: true, forcedMovement: figureA.EnemiesWith(authority));
-		potentialAbilityState?.SetPerformed();
+		Figure figureA = hexObjectA as Figure;
+		Figure figureB = hexObjectB as Figure;
+
+		if(figureA != null)
+		{
+			await ExitHex(potentialAbilityState, figureA, authority);
+		}
+
+		if(figureB != null)
+		{
+			await ExitHex(potentialAbilityState, figureB, authority);
+			await EnterHex(potentialAbilityState, figureB, authority, hexA,
+				triggerHexEffects: true, setPosition: true, forcedMovement: figureB.EnemiesWith(authority));
+		}
+		else
+		{
+			hexObjectB.SetOriginHexAndRotation(hexA, setPosition: true);
+		}
+
+		if(figureA != null)
+		{
+			await EnterHex(potentialAbilityState, figureA, authority, hexB,
+				triggerHexEffects: true, setPosition: true, forcedMovement: figureA.EnemiesWith(authority));
+			potentialAbilityState?.SetPerformed();
+		}
+		else
+		{
+			hexObjectA.SetOriginHexAndRotation(hexB, setPosition: true);
+		}
 
 		return true;
 	}

--- a/Game/Scripts/Scenario/HexObjects/Character.cs
+++ b/Game/Scripts/Scenario/HexObjects/Character.cs
@@ -371,6 +371,10 @@ public partial class Character : Figure
 				if(IsDead || !TakingTurn || RoundCardData.All(data =>
 					   !data.CanPlayBasicBottom && !data.CanPlayBottom && !data.CanPlayBasicTop && !data.CanPlayTop))
 				{
+					foreach(AbilityCard roundCard in RoundCards.Where(card => card.CardState == CardState.Playing))
+					{
+						await AbilityCmd.DiscardCard(roundCard);
+					}
 					break;
 				}
 


### PR DESCRIPTION
1. Fixes Nutrient Overdose condition
2. Fixes Dizzying Release flow, allows to skip any part of it (I think it was implemented that way in the beginning and then I changed it for some reason)
3. Fixes Spirit Caller PlusOneCurse AMD index
4. Fixes Burning Pit not being discarded when dead
5. Small improvement to Ethreal Canine damage display
6. Fixes Horde of Bones not swapping with a coin
7. For that, implement swap of any hexobjects and not just figures
8. Fix Midnight Feast wrong unsubscribe crash
9. Fixes Smoky Shroud bottom not doing 1 damage if the spirit died between the abilities
10. Fixes some edge cases of spirit alignment
11. Fixes some OtherAbilities not setting Performed
12. Fixes that if a Character had some cards in "Playing" state but none had available Actions, they would be stuck in "Playing" state forever ( fixes Nutrient Overdose )
13. Fixes Spirits affected by retaliate
14. Fixes incorrect copy-paste perk of Spirit Caller
15. Fixes Ethreal Canine bottom giving bonus to more than 1 attack
16. Fixes missing description on spirit barrage element consumption
17. Fixes moon earring incorrect prosperity level and atlas index